### PR TITLE
Drop PHP 7.4 support, require PHP 8.2+, upgrade PHPUnit to v11

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.2'
 
       - name: Install WP-CLI
         run: |
@@ -52,7 +52,7 @@ jobs:
 
     - uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.2'
 
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,13 +21,13 @@ env:
 jobs:
   phpunit:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
         php:
-          - '7.4'
           - '8.2'
+          - '8.3'
 
     steps:
     - uses: actions/checkout@v4
@@ -53,23 +53,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-php-
 
-    - name: Install dependencies (PHP 7.4)
-      if: matrix.php == '7.4'
+    - name: Install dependencies
       run: |
         bash bin/install-wp-tests.sh wordpress_test root root localhost latest
         composer install --prefer-dist --no-progress
 
-    - name: Install dependencies (other PHP versions)
-      if: matrix.php != '7.4'
-      run: |
-        bash bin/install-wp-tests.sh wordpress_test root root localhost latest
-        composer install --prefer-dist --no-progress --ignore-platform-reqs
-
     - name: Run test suite
       run: |
         composer dump-autoload -o
-        curl -ksSfL -o ~/phpunit-9.phar https://phar.phpunit.de/phpunit-9.phar
-        php ~/phpunit-9.phar
+        vendor/bin/phpunit
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     }
   ],
   "require": {
-    "php": ">=7.3",
+    "php": ">=8.2",
     "cmb2/cmb2": "^2.10.1",
     "mustardbees/cmb-field-select2": "3.0.4",
     "geocoder-php/nominatim-provider": "^5.7",
@@ -49,11 +49,10 @@
   },
   "require-dev": {
     "mockery/mockery": "^1.6.6",
-    "phpunit/phpunit": "^8.5.34",
+    "phpunit/phpunit": "^11.0",
     "yoast/phpunit-polyfills": "^2.0",
     "wp-coding-standards/wpcs": "^2.3",
     "phpcompatibility/phpcompatibility-wp": "^2.1.4",
-    "slope-it/clock-mock": "^0.4.0",
-    "phpunit/php-code-coverage": "^7.0.15"
+    "slope-it/clock-mock": "^0.4.0"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,10 @@
 <?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
 	bootstrap="tests/php/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
 	>
 	<testsuites>
 		<testsuite name="default">
@@ -18,15 +15,14 @@
         <ini name="xdebug.mode" value="coverage" />
     </php>
     <logging>
-        <testdoxXml outputFile="build/logs/xml.log" />
-        <testdoxHtml outputFile="build/logs/html.log" />
-        <text outputFile="build/logs/text.log"/>
+        <junit outputFile="build/logs/junit.xml"/>
     </logging>
-
-    <coverage>
+    <source>
         <include>
             <directory>./src</directory>
         </include>
+    </source>
+    <coverage>
         <report>
             <clover outputFile="build/logs/clover.xml"/>
             <html outputDirectory="build/report" />


### PR DESCRIPTION
## Summary

PHP 7.4 has been end-of-life since November 2022 (3+ years without security patches). 82%+ of WordPress sites already run PHP 8.x. This PR bumps the minimum to PHP 8.2 — the lowest currently-maintained PHP version — and upgrades the test toolchain accordingly.

### Changes

**`composer.json`**
- PHP constraint: `>=7.3` → `>=8.2`
- PHPUnit: `^8.5` → `^11.0` (PHPUnit 8 is EOL; v11 requires PHP 8.2+)
- Remove `phpunit/php-code-coverage` (now bundled inside PHPUnit 11)

**`phpunit.xml.dist`**
- Schema updated to PHPUnit 11
- `<coverage><include>` migrated to top-level `<source>` element (PHPUnit 10+ format)
- Removed deprecated attributes: `convertErrorsToExceptions`, `convertNoticesToExceptions`, `convertWarningsToExceptions`
- Replaced removed logging types (`testdoxXml`, `testdoxHtml`, `text`) with `junit`

**`.github/workflows/phpunit.yml`**
- Matrix: `[7.4, 8.2]` → `[8.2, 8.3]`
- Removed PHP 7.4 special-case install step (`--ignore-platform-reqs` no longer needed)
- Use `vendor/bin/phpunit` instead of a downloaded phar
- Runner bumped from `ubuntu-20.04` to `ubuntu-22.04`

**`.github/workflows/compile.yml`**
- PHP version updated from `7.4` to `8.2` in both jobs

## Notes

- No runtime code changes required — the codebase already uses PHP 7.4-style typed properties/return types with no 7.x-only patterns
- PHPUnit 10/11 removed a few APIs (`withConsecutive`, `getMockBuilder()->setMethods()`, etc.) — if test runs surface failures, those test files will need small updates
- `yoast/phpunit-polyfills ^2.0` remains and handles cross-version polyfilling

## Test plan

- [ ] Run `composer install` and confirm PHPUnit 11 resolves cleanly
- [ ] Run `vendor/bin/phpunit` locally against PHP 8.2 and confirm test suite passes
- [ ] Confirm CI matrix runs on PHP 8.2 and 8.3 without the old PHP 7.4 job

https://claude.ai/code/session_01JA2idCjLjHr7dNGMs6CYiv