### PR TITLE
Add "Try with demo data" onboarding button to admin dashboard

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -120,6 +120,44 @@ function commonsbooking_admin() {
 			'nonce'    => wp_create_nonce( 'cb_get_booking_code' ),
 		)
 	);
+
+	/**
+	 * Ajax - create demo data (onboarding button on the dashboard)
+	 */
+	wp_localize_script(
+		'cb-scripts-admin',
+		'cb_ajax_demo_data',
+		array(
+			'ajax_url'      => admin_url( 'admin-ajax.php' ),
+			'nonce'         => wp_create_nonce( 'cb_create_demo_data' ),
+			'creating_text' => __( 'Creating demo data…', 'commonsbooking' ),
+			'success_text'  => __( 'Demo data created! Redirecting…', 'commonsbooking' ),
+			'error_text'    => __( 'An error occurred. Please try again.', 'commonsbooking' ),
+		)
+	);
+
+	wp_add_inline_script(
+		'cb-scripts-admin',
+		'jQuery(document).ready(function($){
+			$("#cb-create-demo-data").on("click",function(){
+				var $btn=$(this),$status=$("#cb-demo-data-status");
+				$btn.prop("disabled",true);
+				$status.text(cb_ajax_demo_data.creating_text);
+				$.post(cb_ajax_demo_data.ajax_url,{action:"cb_create_demo_data",nonce:cb_ajax_demo_data.nonce},function(response){
+					if(response.success){
+						$status.text(cb_ajax_demo_data.success_text);
+						setTimeout(function(){window.location.href=response.data.redirect_url;},1200);
+					}else{
+						$status.text((response.data&&response.data.message)||cb_ajax_demo_data.error_text);
+						$btn.prop("disabled",false);
+					}
+				}).fail(function(){
+					$status.text(cb_ajax_demo_data.error_text);
+					$btn.prop("disabled",false);
+				});
+			});
+		});'
+	);
 }
 
 add_action( 'admin_enqueue_scripts', 'commonsbooking_admin' );

--- a/includes/Public.php
+++ b/includes/Public.php
@@ -135,6 +135,7 @@ if ( is_admin() ) {
 	// getting booking code for new backend booking AJAX
 	add_action( 'wp_ajax_cb_get_booking_code', array( \CommonsBooking\View\Booking::class, 'getBookingCode_AJAX' ) );
 	add_action( 'wp_ajax_cb_orphaned_booking_migration', array( \CommonsBooking\Service\MassOperations::class, 'ajaxMigrateOrphaned' ) );
+	add_action( 'wp_ajax_cb_create_demo_data', array( \CommonsBooking\Service\DemoData::class, 'ajaxCreateDemoData' ) );
 }
 
 // Map ajax

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -57,6 +57,11 @@ class Plugin {
 		// Init booking codes table
 		BookingCodes::initBookingCodesTable();
 
+		// Record installation date for demo-data button visibility window
+		if ( ! get_option( \CommonsBooking\Service\DemoData::INSTALL_DATE_OPTION ) ) {
+			update_option( \CommonsBooking\Service\DemoData::INSTALL_DATE_OPTION, time() );
+		}
+
 		self::clearCache();
 	}
 
@@ -323,6 +328,11 @@ class Plugin {
 	}
 
 	public static function admin_init() {
+		// Set installation date if not yet recorded (covers existing installs that were not re-activated)
+		if ( ! get_option( \CommonsBooking\Service\DemoData::INSTALL_DATE_OPTION ) ) {
+			update_option( \CommonsBooking\Service\DemoData::INSTALL_DATE_OPTION, time() );
+		}
+
 		// check if we have a new version and run tasks
 		Upgrade::runTasksAfterUpdate();
 

--- a/src/Service/DemoData.php
+++ b/src/Service/DemoData.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace CommonsBooking\Service;
+
+use CommonsBooking\Model\Timeframe;
+
+/**
+ * Creates a set of demo posts (location, item, timeframe, bookings, page) so that
+ * new users can explore the plugin immediately after installation.
+ *
+ * The "Try with demo data" button on the dashboard is controlled by shouldShowButton():
+ *  - hidden once any CB custom post type data exists
+ *  - hidden after 7 days from plugin installation
+ *  - hidden once the demo data has already been created
+ */
+class DemoData {
+
+	const CREATED_OPTION      = COMMONSBOOKING_PLUGIN_SLUG . '_demo_data_created';
+	const INSTALL_DATE_OPTION = COMMONSBOOKING_PLUGIN_SLUG . '_install_date';
+
+	/**
+	 * Returns true when the "Try with demo data" button should be visible.
+	 */
+	public static function shouldShowButton(): bool {
+		// Already clicked once
+		if ( self::hasBeenCreated() ) {
+			return false;
+		}
+
+		// Any CB CPT data already exists
+		foreach ( [ 'cb_location', 'cb_item', 'cb_timeframe', 'cb_booking' ] as $postType ) {
+			$posts = get_posts( [
+				'post_type'      => $postType,
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+			] );
+			if ( ! empty( $posts ) ) {
+				return false;
+			}
+		}
+
+		// More than 7 days since installation
+		$installDate = get_option( self::INSTALL_DATE_OPTION );
+		if ( $installDate && ( time() - (int) $installDate ) > ( 7 * DAY_IN_SECONDS ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns true when demo data has already been created.
+	 */
+	public static function hasBeenCreated(): bool {
+		return (bool) get_option( self::CREATED_OPTION );
+	}
+
+	/**
+	 * Creates the full demo dataset and marks it as done.
+	 *
+	 * @return array{ page_url: string, page_id: int }
+	 */
+	public static function create(): array {
+		$adminId = get_current_user_id() ?: 1;
+
+		// --- Location ---
+		$locationId = wp_insert_post( [
+			'post_title'  => 'Demo Location',
+			'post_type'   => 'cb_location',
+			'post_status' => 'publish',
+			'post_author' => $adminId,
+		] );
+
+		// --- Item ---
+		$itemId = wp_insert_post( [
+			'post_title'  => 'Demo Item',
+			'post_type'   => 'cb_item',
+			'post_status' => 'publish',
+			'post_author' => $adminId,
+		] );
+
+		// --- Bookable Timeframe: -60 days to +60 days ---
+		$timeframeId = wp_insert_post( [
+			'post_title'  => 'Demo Timeframe',
+			'post_type'   => 'cb_timeframe',
+			'post_status' => 'publish',
+			'post_author' => $adminId,
+		] );
+		update_post_meta( $timeframeId, 'type', Timeframe::BOOKABLE_ID );
+		update_post_meta( $timeframeId, 'location-id', $locationId );
+		update_post_meta( $timeframeId, 'item-id', $itemId );
+		update_post_meta( $timeframeId, 'repetition-start', strtotime( '-60 days' ) );
+		update_post_meta( $timeframeId, 'repetition-end', strtotime( '+60 days' ) );
+		update_post_meta( $timeframeId, 'full-day', 'on' );
+		update_post_meta( $timeframeId, 'timeframe-repetition', 'w' );
+		update_post_meta( $timeframeId, 'weekdays', [ '1', '2', '3', '4', '5', '6', '7' ] );
+		update_post_meta( $timeframeId, 'timeframe-max-days', 3 );
+		update_post_meta( $timeframeId, 'timeframe-advance-booking-days', 30 );
+		update_post_meta( $timeframeId, 'item-select', Timeframe::SELECTION_MANUAL_ID );
+		update_post_meta( $timeframeId, 'location-select', Timeframe::SELECTION_MANUAL_ID );
+		update_post_meta( $timeframeId, 'start-time', '8:00 AM' );
+		update_post_meta( $timeframeId, 'end-time', '12:00 PM' );
+		update_post_meta( $timeframeId, 'grid', 0 );
+
+		// --- 3 Bookings (2 past, 1 future) ---
+		$bookingDates = [
+			[ strtotime( '-14 days midnight' ), strtotime( '-12 days midnight' ) - 1 ],
+			[ strtotime( '-7 days midnight' ),  strtotime( '-5 days midnight' ) - 1  ],
+			[ strtotime( '+3 days midnight' ),  strtotime( '+5 days midnight' ) - 1  ],
+		];
+
+		foreach ( $bookingDates as $dates ) {
+			$bookingId = wp_insert_post( [
+				'post_title'  => 'Demo Booking',
+				'post_type'   => 'cb_booking',
+				'post_status' => 'confirmed',
+				'post_author' => $adminId,
+			] );
+			update_post_meta( $bookingId, 'type', Timeframe::BOOKING_ID );
+			update_post_meta( $bookingId, 'location-id', $locationId );
+			update_post_meta( $bookingId, 'item-id', $itemId );
+			update_post_meta( $bookingId, 'repetition-start', $dates[0] );
+			update_post_meta( $bookingId, 'repetition-end', $dates[1] );
+			update_post_meta( $bookingId, 'start-time', '12:00 AM' );
+			update_post_meta( $bookingId, 'end-time', '23:59' );
+			update_post_meta( $bookingId, 'timeframe-repetition', 'w' );
+			update_post_meta( $bookingId, 'timeframe-max-days', 3 );
+			update_post_meta( $bookingId, 'grid', 0 );
+			update_post_meta( $bookingId, 'weekdays', [ '1', '2', '3', '4', '5', '6', '7' ] );
+		}
+
+		// --- Private page with [cb_bookings] shortcode ---
+		$pageId = wp_insert_post( [
+			'post_title'   => 'My Bookings',
+			'post_content' => '[cb_bookings]',
+			'post_status'  => 'private',
+			'post_type'    => 'page',
+			'post_author'  => $adminId,
+		] );
+
+		update_option( self::CREATED_OPTION, true );
+
+		return [
+			'page_id'  => $pageId,
+			'page_url' => get_permalink( $pageId ),
+		];
+	}
+
+	/**
+	 * AJAX handler for the "Try with demo data" button.
+	 * Expects POST: action=cb_create_demo_data, nonce=<cb_create_demo_data nonce>
+	 */
+	public static function ajaxCreateDemoData(): void {
+		check_ajax_referer( 'cb_create_demo_data', 'nonce' );
+
+		if ( ! current_user_can( 'manage_' . COMMONSBOOKING_PLUGIN_SLUG ) ) {
+			wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'commonsbooking' ) ] );
+		}
+
+		try {
+			$result = self::create();
+			wp_send_json_success( [
+				'redirect_url' => admin_url( 'admin.php?page=cb-dashboard' ),
+				'page_url'     => $result['page_url'],
+			] );
+		} catch ( \Exception $e ) {
+			wp_send_json_error( [ 'message' => $e->getMessage() ] );
+		}
+	}
+}

--- a/templates/dashboard-index.php
+++ b/templates/dashboard-index.php
@@ -1,5 +1,17 @@
 <h1>Dashboard</h1>
 <!-- based on WordPress Dashboard -->
+<?php if ( \CommonsBooking\Service\DemoData::shouldShowButton() ) : ?>
+<div class="wrap">
+	<div class="cb_welcome-panel" style="background:#f0f8e8;border-left:4px solid #67b32a;padding:16px 20px;margin-bottom:10px;">
+		<h3 style="margin-top:0"><?php echo esc_html__( 'Getting started with CommonsBooking', 'commonsbooking' ); ?></h3>
+		<p><?php echo esc_html__( 'No items or locations yet? Load sample data to explore the plugin.', 'commonsbooking' ); ?></p>
+		<button id="cb-create-demo-data" class="button button-primary">
+			<?php echo esc_html__( 'Try with demo data', 'commonsbooking' ); ?>
+		</button>
+		<span id="cb-demo-data-status" style="margin-left:10px;font-style:italic;"></span>
+	</div>
+</div>
+<?php endif; ?>
 <div class="wrap">
 	<div id="cb_welcome-panel" class="cb_welcome-panel">
 		<div class="cb_welcome-panel-content">

--- a/tests/php/Service/DemoDataTest.php
+++ b/tests/php/Service/DemoDataTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace CommonsBooking\Tests\Service;
+
+use CommonsBooking\Service\DemoData;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use SlopeIt\ClockMock\ClockMock;
+
+class DemoDataTest extends CustomPostTypeTest {
+
+	protected function setUp(): void {
+		parent::setUp();
+		// Clean slate for every test: delete the flags set by DemoData
+		delete_option( DemoData::CREATED_OPTION );
+		delete_option( DemoData::INSTALL_DATE_OPTION );
+	}
+
+	protected function tearDown(): void {
+		delete_option( DemoData::CREATED_OPTION );
+		delete_option( DemoData::INSTALL_DATE_OPTION );
+		parent::tearDown();
+	}
+
+	// -----------------------------------------------------------------------
+	// shouldShowButton() tests
+	// -----------------------------------------------------------------------
+
+	public function testShouldShowButton_noDataNoInstallDate() {
+		// No CPTs, no install date → should show
+		$this->assertTrue( DemoData::shouldShowButton() );
+	}
+
+	public function testShouldShowButton_withinSevenDays() {
+		update_option( DemoData::INSTALL_DATE_OPTION, time() );
+		$this->assertTrue( DemoData::shouldShowButton() );
+	}
+
+	public function testShouldShowButton_afterSevenDays() {
+		update_option( DemoData::INSTALL_DATE_OPTION, strtotime( '-8 days' ) );
+		$this->assertFalse( DemoData::shouldShowButton() );
+	}
+
+	public function testShouldShowButton_withExistingLocation() {
+		$this->createLocation( 'Existing Location', 'publish' );
+		$this->assertFalse( DemoData::shouldShowButton() );
+	}
+
+	public function testShouldShowButton_withExistingItem() {
+		$this->createItem( 'Existing Item', 'publish' );
+		$this->assertFalse( DemoData::shouldShowButton() );
+	}
+
+	public function testShouldShowButton_afterDemoCreated() {
+		update_option( DemoData::CREATED_OPTION, true );
+		$this->assertFalse( DemoData::shouldShowButton() );
+	}
+
+	// -----------------------------------------------------------------------
+	// create() tests
+	// -----------------------------------------------------------------------
+
+	public function testCreate_setsCreatedFlag() {
+		DemoData::create();
+		$this->assertTrue( DemoData::hasBeenCreated() );
+	}
+
+	public function testCreate_createsLocation() {
+		DemoData::create();
+		$locations = get_posts( [
+			'post_type'      => 'cb_location',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+		] );
+		$this->assertNotEmpty( $locations );
+		$titles = array_column( $locations, 'post_title' );
+		$this->assertContains( 'Demo Location', $titles );
+	}
+
+	public function testCreate_createsItem() {
+		DemoData::create();
+		$items = get_posts( [
+			'post_type'      => 'cb_item',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+		] );
+		$this->assertNotEmpty( $items );
+		$titles = array_column( $items, 'post_title' );
+		$this->assertContains( 'Demo Item', $titles );
+	}
+
+	public function testCreate_createsTimeframeWithCorrectMeta() {
+		$result      = DemoData::create();
+		$timeframes  = get_posts( [
+			'post_type'      => 'cb_timeframe',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+			'title'          => 'Demo Timeframe',
+		] );
+		$this->assertNotEmpty( $timeframes );
+		$tf = $timeframes[0];
+
+		$locationId = get_post_meta( $tf->ID, 'location-id', true );
+		$itemId     = get_post_meta( $tf->ID, 'item-id', true );
+
+		$this->assertNotEmpty( $locationId );
+		$this->assertNotEmpty( $itemId );
+		$this->assertEquals( \CommonsBooking\Model\Timeframe::BOOKABLE_ID, (int) get_post_meta( $tf->ID, 'type', true ) );
+	}
+
+	public function testCreate_createsThreeBookings() {
+		DemoData::create();
+		$bookings = get_posts( [
+			'post_type'      => 'cb_booking',
+			'post_status'    => 'confirmed',
+			'posts_per_page' => -1,
+		] );
+		$this->assertCount( 3, $bookings );
+	}
+
+	public function testCreate_twoPastBookings() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		DemoData::create();
+		$bookings = get_posts( [
+			'post_type'      => 'cb_booking',
+			'post_status'    => 'confirmed',
+			'posts_per_page' => -1,
+		] );
+
+		$now  = time();
+		$past = array_filter( $bookings, function ( $b ) use ( $now ) {
+			return (int) get_post_meta( $b->ID, 'repetition-end', true ) < $now;
+		} );
+		$this->assertCount( 2, $past );
+		ClockMock::reset();
+	}
+
+	public function testCreate_oneFutureBooking() {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		DemoData::create();
+		$bookings = get_posts( [
+			'post_type'      => 'cb_booking',
+			'post_status'    => 'confirmed',
+			'posts_per_page' => -1,
+		] );
+
+		$now    = time();
+		$future = array_filter( $bookings, function ( $b ) use ( $now ) {
+			return (int) get_post_meta( $b->ID, 'repetition-start', true ) > $now;
+		} );
+		$this->assertCount( 1, $future );
+		ClockMock::reset();
+	}
+
+	public function testCreate_createsPrivatePage() {
+		DemoData::create();
+		$pages = get_posts( [
+			'post_type'      => 'page',
+			'post_status'    => 'private',
+			'posts_per_page' => -1,
+			'title'          => 'My Bookings',
+		] );
+		$this->assertNotEmpty( $pages );
+		$this->assertStringContainsString( '[cb_bookings]', $pages[0]->post_content );
+	}
+
+	public function testCreate_returnsPageUrl() {
+		$result = DemoData::create();
+		$this->assertArrayHasKey( 'page_url', $result );
+		$this->assertNotEmpty( $result['page_url'] );
+	}
+}


### PR DESCRIPTION
Adds a DemoData service that creates a demo location, item, bookable
timeframe, 3 confirmed bookings (2 past + 1 future), and a private
page with [cb_bookings] shortcode in one click.

The banner button appears on the dashboard only when no CB custom post
type data exists and the install is within the 7-day onboarding window;
it disappears permanently once demo data is created or the window closes.

- src/Service/DemoData.php         — new service (create, shouldShowButton, AJAX handler)
- tests/php/Service/DemoDataTest.php — 15 red/green PHPUnit tests
- src/Plugin.php                   — record install date on activation + admin_init fallback
- includes/Public.php              — register wp_ajax_cb_create_demo_data
- includes/Admin.php               — wp_localize_script + inline JS for button
- templates/dashboard-index.php   — conditional demo-data banner

https://claude.ai/code/session_01QvGeLKxbtPAEZm4SbdkwNm