### PR TITLE
feat: add commonsbooking_options_array filter hook

### DIFF
--- a/docs/de/documentation/advanced-functionality/hooks-and-filters.md
+++ b/docs/de/documentation/advanced-functionality/hooks-and-filters.md
@@ -96,6 +96,7 @@ zurückgibt.
   * commonsbooking_mail_body
   * commonsbooking_mail_attachment
   * commonsbooking_disableCache
+  * commonsbooking_options_array
 
 Es gibt auch Filter Hooks, mit denen du zusätzliche Benutzerrollen, die
 zusätzlich zum CB Manager Artikel und Standorte administrieren können,
@@ -182,4 +183,75 @@ Nutzungs-Beispiel:
 ```php
 // Sets the mobile calendar view to display 2 month
 add_filter('commonsbooking_mobile_calendar_month_count', fn(): int => 2);
+```
+
+### Filter `commonsbooking_options_array`
+
+Mit diesem Filter kannst du das vollständige Options-Array, das alle Tabs,
+Feldgruppen und Felder auf der CommonsBooking-Einstellungsseite definiert,
+vor der Darstellung verändern. Dies ist der richtige Erweiterungspunkt, um neue
+Einstellungs-Tabs hinzuzufügen oder Felder zu bestehenden Gruppen anzufügen,
+ohne die Plugin-Kerndateien zu verändern.
+
+Die an deinen Callback übergebene Struktur entspricht dem Array in
+[`OptionsArray.php`](https://github.com/wielebenwir/commonsbooking/blob/master/includes/OptionsArray.php):
+
+```
+array(
+    'tab_id' => array(
+        'title'        => string,
+        'id'           => string,
+        'field_groups' => array(
+            'group_id' => array(
+                'title'  => string,
+                'id'     => string,
+                'fields' => array( /* CMB2-Felder */ ),
+            ),
+        ),
+    ),
+)
+```
+
+#### Beispiel: Einen neuen Einstellungs-Tab hinzufügen
+
+Verwende einen plugin-spezifischen Schlüssel, um bestehende Tabs nicht zu überschreiben.
+
+```php
+add_filter( 'commonsbooking_options_array', function ( array $options_array ): array {
+    $options_array['my_plugin_tab'] = array(
+        'title'        => __( 'Mein Plugin', 'my-plugin' ),
+        'id'           => 'my_plugin_tab',
+        'field_groups' => array(
+            'my_plugin_group' => array(
+                'title'  => __( 'Mein Plugin Einstellungen', 'my-plugin' ),
+                'id'     => 'my_plugin_group',
+                'fields' => array(
+                    array(
+                        'name'    => __( 'Funktion aktivieren', 'my-plugin' ),
+                        'id'      => 'my_plugin_enable_feature',
+                        'type'    => 'checkbox',
+                        'default' => false,
+                    ),
+                ),
+            ),
+        ),
+    );
+    return $options_array;
+} );
+```
+
+#### Beispiel: Ein Feld zu einer bestehenden Gruppe hinzufügen
+
+Dieses Beispiel fügt ein Textfeld zur bestehenden Gruppe `posttypes` im Tab `general` hinzu.
+
+```php
+add_filter( 'commonsbooking_options_array', function ( array $options_array ): array {
+    $options_array['general']['field_groups']['posttypes']['fields'][] = array(
+        'name'    => __( 'Eigenes Slug-Suffix', 'my-plugin' ),
+        'id'      => 'my_plugin_custom_suffix',
+        'type'    => 'text',
+        'default' => '',
+    );
+    return $options_array;
+} );
 ```

--- a/docs/en/documentation/advanced-functionality/hooks-and-filters.md
+++ b/docs/en/documentation/advanced-functionality/hooks-and-filters.md
@@ -88,6 +88,7 @@ receives a value, modifies it, and then returns it.
   * commonsbooking_mail_body
   * commonsbooking_mail_attachment
   * commonsbooking_disableCache
+  * commonsbooking_options_array
 
 There are also filter hooks that allow you to add additional user roles
 akin to the CB Manager that can manage items and locations.
@@ -166,4 +167,74 @@ How many months are displayed in the mobile calendar view can be adjusted using 
 ```php
 // Sets the mobile calendar view to display 2 months
 add_filter('commonsbooking_mobile_calendar_month_count', fn(): int => 2);
+```
+
+### Filter `commonsbooking_options_array`
+
+This filter allows you to modify the full options array that defines all tabs,
+field groups, and fields on the CommonsBooking admin settings page before it is
+rendered. This is the correct extension point for adding new settings tabs or
+appending fields to existing groups without modifying plugin core files.
+
+The structure passed to your callback mirrors the array in
+[`OptionsArray.php`](https://github.com/wielebenwir/commonsbooking/blob/master/includes/OptionsArray.php):
+
+```
+array(
+    'tab_id' => array(
+        'title'        => string,
+        'id'           => string,
+        'field_groups' => array(
+            'group_id' => array(
+                'title'  => string,
+                'id'     => string,
+                'fields' => array( /* CMB2 field arrays */ ),
+            ),
+        ),
+    ),
+)
+```
+
+#### Example: Add a completely new settings tab
+
+Use a plugin-prefixed key to avoid overwriting an existing tab.
+
+```php
+add_filter( 'commonsbooking_options_array', function ( array $options_array ): array {
+    $options_array['my_plugin_tab'] = array(
+        'title'        => __( 'My Plugin', 'my-plugin' ),
+        'id'           => 'my_plugin_tab',
+        'field_groups' => array(
+            'my_plugin_group' => array(
+                'title'  => __( 'My Plugin Settings', 'my-plugin' ),
+                'id'     => 'my_plugin_group',
+                'fields' => array(
+                    array(
+                        'name'    => __( 'Enable feature', 'my-plugin' ),
+                        'id'      => 'my_plugin_enable_feature',
+                        'type'    => 'checkbox',
+                        'default' => false,
+                    ),
+                ),
+            ),
+        ),
+    );
+    return $options_array;
+} );
+```
+
+#### Example: Add a field to an existing group
+
+This appends a text field to the `posttypes` group inside the `general` tab.
+
+```php
+add_filter( 'commonsbooking_options_array', function ( array $options_array ): array {
+    $options_array['general']['field_groups']['posttypes']['fields'][] = array(
+        'name'    => __( 'Custom slug suffix', 'my-plugin' ),
+        'id'      => 'my_plugin_custom_suffix',
+        'type'    => 'text',
+        'default' => '',
+    );
+    return $options_array;
+} );
 ```

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -546,9 +546,13 @@ class Plugin {
 
 	/**
 	 * Register Admin-Options
+	 *
+	 * Applies the 'commonsbooking_options_array' filter before processing
+	 * so that external code can add, modify or remove tabs and their field groups.
 	 */
 	public static function registerAdminOptions() {
 		$options_array = include COMMONSBOOKING_PLUGIN_DIR . '/includes/OptionsArray.php';
+		$options_array = apply_filters( 'commonsbooking_options_array', $options_array );
 		foreach ( $options_array as $tab_id => $tab ) {
 			new OptionsTab( $tab_id, $tab );
 		}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -560,6 +560,8 @@ class Plugin {
 		 * or remove entries from the CommonsBooking admin settings page without
 		 * modifying plugin core files.
 		 *
+		 * @since 2.10.10
+		 *
 		 * @param array $options_array {
 		 *     Associative array of tab definitions, keyed by tab ID.
 		 *
@@ -579,6 +581,7 @@ class Plugin {
 		 *         }
 		 *     }
 		 * }
+		 * @return array The filtered options array.
 		 */
 		$options_array = apply_filters( 'commonsbooking_options_array', $options_array );
 		foreach ( $options_array as $tab_id => $tab ) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -552,6 +552,34 @@ class Plugin {
 	 */
 	public static function registerAdminOptions() {
 		$options_array = include COMMONSBOOKING_PLUGIN_DIR . '/includes/OptionsArray.php';
+
+		/**
+		 * Filters the options array before it is processed into admin settings tabs.
+		 *
+		 * Use this filter to add new tabs, append fields to existing field groups,
+		 * or remove entries from the CommonsBooking admin settings page without
+		 * modifying plugin core files.
+		 *
+		 * @param array $options_array {
+		 *     Associative array of tab definitions, keyed by tab ID.
+		 *
+		 *     @type array $tab {
+		 *         @type string $title        Tab title shown in the admin UI.
+		 *         @type string $id           Tab identifier (must be unique).
+		 *         @type bool   $is_top_level Optional. Makes this the top-level plugin page.
+		 *         @type array  $field_groups {
+		 *             Associative array of field group definitions, keyed by group ID.
+		 *
+		 *             @type array $group {
+		 *                 @type string $title  Group heading shown in the form.
+		 *                 @type string $id     Group identifier (must be unique within the tab).
+		 *                 @type string $desc   Optional. Description HTML shown below the heading.
+		 *                 @type array  $fields Array of CMB2 field definition arrays.
+		 *             }
+		 *         }
+		 *     }
+		 * }
+		 */
 		$options_array = apply_filters( 'commonsbooking_options_array', $options_array );
 		foreach ( $options_array as $tab_id => $tab ) {
 			new OptionsTab( $tab_id, $tab );


### PR DESCRIPTION
Allows external plugins and themes to modify the admin settings
page structure (tabs, field groups, fields) without patching core.
Documents the new hook in both English and German.

https://claude.ai/code/session_013gJ7DCbnqyP654LPAc9e4s