### PR TITLE
Add contrib/ community snippet library scaffold

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -26,3 +26,4 @@ tsconfig.*
 webpack.config.js
 phpstan.neon
 phpstan-baseline.neon
+/contrib/

--- a/Readme.md
+++ b/Readme.md
@@ -61,6 +61,7 @@ Contributions are welcome either through
 
 * Translating WordPress into your native tongue ([see the already existing WordPress Plugin Translations](https://translate.wordpress.org/projects/wp-plugins/commonsbooking/))
 * Improving or translating the documentation at https://commonsbooking.org
+* Sharing PHP snippets for customizing CommonsBooking via the [community snippet library](contrib/)
 * or through developing and testing new versions of the application (see [Development](#development))
 
 ## Development

--- a/contrib/CONTRIBUTING.md
+++ b/contrib/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to CommonsBooking Community Snippets
+
+Thanks for sharing your snippet! The goal of this library is to make useful CommonsBooking customizations discoverable and reusable without requiring changes to the core plugin.
+
+---
+
+## Before you start
+
+- Your snippet must use CommonsBooking's public hook/filter/shortcode API — no monkey-patching private methods or modifying plugin files directly.
+- All contributions must be licensed **GPL-2.0+** (required for WordPress compatibility).
+- This library targets **technical users**: developers and admins who paste PHP into a Code Snippets plugin or `functions.php`. No UI code, no settings pages.
+
+---
+
+## Step-by-step
+
+### 1. Copy the template
+
+```
+cp _TEMPLATE.php snippets/filters/filter-my-feature-description.php
+```
+
+### 2. Name the file
+
+Use the pattern: `{type}-{hook-name}-{what-it-does}.php`
+
+| Type | Prefix | Example |
+|------|--------|---------|
+| `apply_filters` | `filter-` | `filter-mail-body-add-location-phone.php` |
+| `add_action` | `action-` | `action-booking-single-before-add-map.php` |
+| `add_shortcode` | `shortcode-` | `shortcode-cb-item-qr-code.php` |
+| Integration with another plugin | `integration-` | `integration-woocommerce-sync-booking.php` |
+
+### 3. Fill the file header
+
+Every snippet **must** start with this header (all fields required unless marked optional):
+
+```php
+/**
+ * Snippet Title: Short human-readable title
+ * Description:   One-sentence explanation of what it does and why it is useful.
+ * Hook/Filter:   commonsbooking_[hook_name]
+ * CB Version:    2.10+
+ * Tested up to:  2.10.8
+ * Author:        Your name or GitHub handle
+ * Author URI:    https://github.com/yourhandle  (optional)
+ * License:       GPL-2.0+
+ * Requires Plugins: other-plugin-slug  (optional, only if another plugin is needed)
+ */
+```
+
+### 4. Security checklist
+
+Before opening a PR, confirm your snippet does **not**:
+
+- [ ] Pass user input directly to database queries (`$wpdb->query( $_GET['x'] )`)
+- [ ] Output user-controlled data without escaping (`echo $_POST['x']`)
+- [ ] Accept form submissions without nonce verification
+- [ ] Use `eval()` or dynamic `include`/`require` with user input
+- [ ] Hard-code credentials, API keys, or email addresses (use variables or settings instead)
+
+### 5. Update README.md
+
+Add a row to the relevant table in `README.md`:
+
+```markdown
+| [your-file.php](snippets/filters/your-file.php) | One-sentence description | 2.10+ |
+```
+
+### 6. Open a PR
+
+The review bar is intentionally low:
+- Does the snippet work?
+- Is the header complete?
+- Does it pass the security checklist above?
+
+No architectural review. No "this should be done differently" gatekeeping. If it works and it's safe, it gets merged.
+
+---
+
+## File structure
+
+```
+contrib/
+├── README.md
+├── CONTRIBUTING.md
+├── LICENSE
+├── _TEMPLATE.php              ← copy this for every new snippet
+├── futureplan.md              ← planned improvements not yet implemented
+├── snippets/
+│   ├── filters/               ← apply_filters customizations
+│   ├── hooks/                 ← add_action customizations
+│   ├── shortcodes/            ← custom shortcodes using CB APIs
+│   └── integrations/         ← CB + another plugin
+└── mini-plugins/              ← full WP plugin packages that depend on CB
+    └── example-addon/
+        ├── example-addon.php
+        └── README.md
+```

--- a/contrib/LICENSE
+++ b/contrib/LICENSE
@@ -1,0 +1,21 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,52 @@
+# CommonsBooking Community Snippets
+
+A community-maintained library of PHP snippets for extending [CommonsBooking](https://github.com/wielebenwir/commonsbooking) — the WordPress plugin for commons-based item sharing.
+
+**Target audience:** Developers and technically fluent site admins who add PHP code via a [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/) or their theme's `functions.php`. No UI, no settings, no installers — just copy, understand, paste.
+
+---
+
+## How to use a snippet
+
+1. Find a snippet that matches your use case in the table below
+2. Read the file header to confirm the required CommonsBooking version
+3. Copy the code into your Code Snippets plugin or `functions.php`
+4. Test on a staging site before deploying to production
+
+---
+
+## Snippets
+
+### Filters
+
+| File | Description | CB Version |
+|------|-------------|------------|
+| [filter-mail-body-add-custom-text.php](snippets/filters/filter-mail-body-add-custom-text.php) | Append custom text to all booking confirmation emails | 2.8+ |
+
+### Hooks (Actions)
+
+| File | Description | CB Version |
+|------|-------------|------------|
+| [action-booking-single-before-show-user-info.php](snippets/hooks/action-booking-single-before-show-user-info.php) | Display extra user info before the booking single template | 2.10.8+ |
+
+### Shortcodes
+
+*No snippets yet — [contribute one!](CONTRIBUTING.md)*
+
+### Integrations
+
+*No snippets yet — [contribute one!](CONTRIBUTING.md)*
+
+### Mini-plugins
+
+*No snippets yet — [contribute one!](CONTRIBUTING.md)*
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). The short version: copy `_TEMPLATE.php`, fill the header, open a PR.
+
+## License
+
+All snippets in this repository are licensed under [GPL-2.0+](LICENSE).

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -21,17 +21,24 @@ A community-maintained library of PHP snippets for extending [CommonsBooking](ht
 
 | File | Description | CB Version |
 |------|-------------|------------|
-| [filter-mail-body-add-custom-text.php](snippets/filters/filter-mail-body-add-custom-text.php) | Append custom text to all booking confirmation emails | 2.8+ |
+| [filter-mail-body-add-custom-text.php](snippets/filters/filter-mail-body-add-custom-text.php) | Append custom text to all booking emails | 2.7.3+ |
+| [filter-mail-subject-add-site-name.php](snippets/filters/filter-mail-subject-add-site-name.php) | Prepend site name to all booking email subjects | 2.7.3+ |
+| [filter-mobile-calendar-show-3-months.php](snippets/filters/filter-mobile-calendar-show-3-months.php) | Show 3 months in the mobile booking calendar | 2.10.5+ |
 
 ### Hooks (Actions)
 
 | File | Description | CB Version |
 |------|-------------|------------|
-| [action-booking-single-before-show-user-info.php](snippets/hooks/action-booking-single-before-show-user-info.php) | Display extra user info before the booking single template | 2.10.8+ |
+| [action-booking-single-before-show-user-info.php](snippets/hooks/action-booking-single-before-show-user-info.php) | Display renter contact info above the booking details (admins only) | 2.10.8+ |
+| [action-item-single-after-add-custom-notice.php](snippets/hooks/action-item-single-after-add-custom-notice.php) | Add a custom notice box below every item page | 2.10.8+ |
+| [action-location-single-after-add-opening-hours.php](snippets/hooks/action-location-single-after-add-opening-hours.php) | Display opening hours from a custom field below a location page | 2.10.8+ |
 
 ### Shortcodes
 
-*No snippets yet — [contribute one!](CONTRIBUTING.md)*
+| File | Shortcode | Description | CB Version |
+|------|-----------|-------------|------------|
+| [shortcode-cb-my-next-booking.php](snippets/shortcodes/shortcode-cb-my-next-booking.php) | `[cb_my_next_booking]` | Show the current user's next confirmed booking | 2.10+ |
+| [shortcode-cb-item-availability-badge.php](snippets/shortcodes/shortcode-cb-item-availability-badge.php) | `[cb_item_availability_badge id="42"]` | Render an available / not-available badge for a specific item | 2.10+ |
 
 ### Integrations
 

--- a/contrib/_TEMPLATE.php
+++ b/contrib/_TEMPLATE.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Snippet Title:     Short human-readable title
+ * Description:       One sentence: what it does and why it is useful.
+ * Hook/Filter:       commonsbooking_<hook_name>
+ * CB Version:        2.10+
+ * Tested up to:      2.10.10
+ * Author:            Your name or GitHub handle
+ * Author URI:        https://github.com/yourhandle  (optional)
+ * License:           GPL-2.0+
+ * Requires Plugins:  other-plugin-slug  (optional, remove if not needed)
+ */
+
+// Do NOT paste this file as-is. Fill the header above and replace
+// the example code below with your actual implementation.
+
+// Example: replace with your callback function and hook registration.
+// Use a unique prefix for your function name to avoid conflicts.
+function myplugin_cb_example_callback() {
+    // your code here
+}
+add_action( 'commonsbooking_before_booking-single', 'myplugin_cb_example_callback' );

--- a/contrib/futureplan.md
+++ b/contrib/futureplan.md
@@ -54,3 +54,56 @@ tested against, fetched from the file headers and rendered in the README.
 
 Define what happens when a CB core hook is renamed or removed: how do we mark
 snippets as deprecated, and how long do we keep them in the library?
+
+---
+
+## Promotion pathway: community snippet → `CommonsBooking\Contrib\*`
+
+This is the most significant future direction for this library.
+
+### The idea
+
+Snippets that prove broadly useful can be promoted by the core team into an
+official optional namespace inside the main plugin — `src/Contrib/` —
+mirroring the pattern of `django.contrib` in Django. These modules:
+
+- Ship in the release zip (unlike community snippets, which are `.distignore`d)
+- Are maintained and tested by the CB core team
+- Live under the PHP namespace `CommonsBooking\Contrib\<ModuleName>`
+- Are **optional by default** — shortcodes/features activate only when used,
+  no settings toggle required
+- Carry the signal "this started as a community idea and proved its value"
+
+### Three-tier model
+
+```
+contrib/snippets/          Community, copy-paste, not shipped
+        ↓ (proven useful for many sites)
+src/Contrib/               Official optional, shipped, CB-maintained
+        ↓ (universally needed)
+src/                       Core plugin
+```
+
+### Promotion criteria (suggested)
+
+A snippet becomes a candidate for `src/Contrib/` when it meets all of:
+
+1. Requested or adopted independently by multiple sites / networks
+2. Uses only public CB hooks, filters, or shortcode APIs (no internals)
+3. Has a single, well-scoped responsibility
+4. The community snippet has been stable across ≥ 1 CB release cycle
+
+### What NOT to promote
+
+- Highly site-specific snippets (custom email text, local contact details)
+- Snippets that require configuration not easily expressible in PHP constants
+- Anything that would need a settings UI — those belong in a separate plugin
+
+### Implementation notes (when ready)
+
+- Create `src/Contrib/` directory with its own `README.md`
+- Each module is a single class file loaded via the existing autoloader
+- Module classes register their hooks/filters in a `register()` method called
+  from the main plugin bootstrap (conditionally, e.g. only if a constant is set
+  or always — depending on the module)
+- Add integration tests under `tests/php/Contrib/`

--- a/contrib/futureplan.md
+++ b/contrib/futureplan.md
@@ -1,0 +1,56 @@
+# Future plan — items not in scope for the initial release
+
+This file tracks ideas and improvements that are deliberately out of scope for the
+MVP of the `contrib/` directory. Nothing here is a commitment. Open an issue to
+discuss any of these before starting work.
+
+---
+
+## Automated testing for snippets
+
+Snippets are currently verified only by human code review. A lightweight test
+harness (e.g. a WordPress unit test bootstrap with CB installed) would let
+contributors add a simple smoke test alongside their snippet file.
+
+**Blocker:** Requires a reproducible CB test environment that runs in CI without
+a full database, which is non-trivial to set up for external contributors.
+
+---
+
+## Snippet metadata index
+
+Generate a machine-readable `index.json` from the PHP file headers so that
+tooling (a website, a CLI, an IDE plugin) can list and search snippets without
+parsing PHP.
+
+**Approach:** A small GitHub Actions workflow that runs `php -r` to extract
+PHPDoc-style headers and emits JSON.
+
+---
+
+## Mini-plugin scaffold / generator
+
+A `bin/new-mini-plugin.sh` script that scaffolds a minimal WordPress plugin
+package (main PHP file, readme.txt, basic structure) so contributors don't
+start from scratch.
+
+---
+
+## Translations / i18n guidance
+
+Snippets that output user-facing strings should wrap them in `__()` / `esc_html__()`.
+A short i18n guide for snippet authors would help establish the pattern early.
+
+---
+
+## Version compatibility matrix
+
+A table (or automated badge) showing which CB version each snippet was last
+tested against, fetched from the file headers and rendered in the README.
+
+---
+
+## Snippet deprecation policy
+
+Define what happens when a CB core hook is renamed or removed: how do we mark
+snippets as deprecated, and how long do we keep them in the library?

--- a/contrib/snippets/filters/filter-mail-body-add-custom-text.php
+++ b/contrib/snippets/filters/filter-mail-body-add-custom-text.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Snippet Title:    Append custom text to all booking emails
+ * Description:      Adds a fixed paragraph at the end of every CommonsBooking
+ *                   email body (confirmation, cancellation, reminder, …).
+ *                   Useful for adding site-specific legal notices, support
+ *                   contacts, or seasonal greetings without touching core templates.
+ * Hook/Filter:      commonsbooking_mail_body
+ * CB Version:       2.7.3+
+ * Tested up to:     2.10.10
+ * Author:           CommonsBooking contributors
+ * License:          GPL-2.0+
+ */
+
+/**
+ * Append a custom paragraph to every CommonsBooking email body.
+ *
+ * @param string $body          The current email body (may contain HTML).
+ * @param string $messageAction The email action type (e.g. 'booking-confirmed').
+ * @return string Modified email body.
+ */
+function myplugin_cb_append_custom_email_text( $body, $messageAction ) {
+    $custom_text = '<p>Questions? Contact us at <a href="mailto:info@example.org">info@example.org</a> or call +49 30 123456.</p>';
+
+    return $body . $custom_text;
+}
+add_filter( 'commonsbooking_mail_body', 'myplugin_cb_append_custom_email_text', 10, 2 );

--- a/contrib/snippets/filters/filter-mail-subject-add-site-name.php
+++ b/contrib/snippets/filters/filter-mail-subject-add-site-name.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Snippet Title:    Prepend site name to all booking email subjects
+ * Description:      Prefixes every CommonsBooking email subject with the
+ *                   WordPress site name so recipients immediately recognise
+ *                   which platform the email came from. Useful when users
+ *                   belong to multiple networks that all run CommonsBooking.
+ *                   Example result: "[My Bikesharing] Your booking is confirmed"
+ * Hook/Filter:      commonsbooking_mail_subject
+ * CB Version:       2.7.3+
+ * Tested up to:     2.10.10
+ * Author:           CommonsBooking contributors
+ * License:          GPL-2.0+
+ */
+
+/**
+ * Prepend the WordPress site name to every CommonsBooking email subject.
+ *
+ * @param string $subject       The current email subject line.
+ * @param string $messageAction The email action type (e.g. 'booking-confirmed').
+ * @return string Modified subject line.
+ */
+function myplugin_cb_prepend_site_name_to_subject( $subject, $messageAction ) {
+    $site_name = get_bloginfo( 'name' );
+
+    return '[' . $site_name . '] ' . $subject;
+}
+add_filter( 'commonsbooking_mail_subject', 'myplugin_cb_prepend_site_name_to_subject', 10, 2 );

--- a/contrib/snippets/filters/filter-mobile-calendar-show-3-months.php
+++ b/contrib/snippets/filters/filter-mobile-calendar-show-3-months.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Snippet Title:    Show 3 months in the mobile booking calendar
+ * Description:      The mobile calendar defaults to 1 month. This snippet
+ *                   increases it to 3 months, giving mobile users a wider
+ *                   booking window without switching to the desktop view.
+ *                   Adjust the return value to any positive integer.
+ * Hook/Filter:      commonsbooking_mobile_calendar_month_count
+ * CB Version:       2.10.5+
+ * Tested up to:     2.10.10
+ * Author:           CommonsBooking contributors
+ * License:          GPL-2.0+
+ */
+
+add_filter( 'commonsbooking_mobile_calendar_month_count', fn (): int => 3 );

--- a/contrib/snippets/hooks/action-booking-single-before-show-user-info.php
+++ b/contrib/snippets/hooks/action-booking-single-before-show-user-info.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Snippet Title:    Show extra user info above the booking single view
+ * Description:      Outputs the booking user's display name and email address
+ *                   directly above the booking-single template. Useful for
+ *                   location admins who want quick access to renter contact
+ *                   details without navigating to the WP Users screen.
+ *                   Only visible to users who can edit the booking post.
+ * Hook/Filter:      commonsbooking_before_booking-single
+ * CB Version:       2.10.8+
+ * Tested up to:     2.10.10
+ * Author:           CommonsBooking contributors
+ * License:          GPL-2.0+
+ */
+
+/**
+ * Render renter contact info before the booking-single template.
+ *
+ * @param int                           $booking_id The booking post ID.
+ * @param \CommonsBooking\Model\Booking $booking    The booking model instance.
+ */
+function myplugin_cb_before_booking_single_user_info( $booking_id, $booking ) {
+    // Only show to users who can edit this booking (admins / CB managers).
+    if ( ! current_user_can( 'edit_post', $booking_id ) ) {
+        return;
+    }
+
+    $author_id = (int) get_post_field( 'post_author', $booking_id );
+    if ( ! $author_id ) {
+        return;
+    }
+
+    $user = get_userdata( $author_id );
+    if ( ! $user ) {
+        return;
+    }
+
+    printf(
+        '<div class="cb-admin-user-info" style="background:#f0f0f0;padding:8px 12px;margin-bottom:12px;border-left:4px solid #0073aa;">'
+        . '<strong>%s</strong> &lt;<a href="mailto:%s">%s</a>&gt;</div>',
+        esc_html( $user->display_name ),
+        esc_attr( $user->user_email ),
+        esc_html( $user->user_email )
+    );
+}
+add_action( 'commonsbooking_before_booking-single', 'myplugin_cb_before_booking_single_user_info', 10, 2 );

--- a/contrib/snippets/hooks/action-item-single-after-add-custom-notice.php
+++ b/contrib/snippets/hooks/action-item-single-after-add-custom-notice.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Snippet Title:    Add a custom notice below every item page
+ * Description:      Outputs a styled info box after the item-single template.
+ *                   Use this for site-wide notices such as pickup rules,
+ *                   insurance reminders, or seasonal availability warnings
+ *                   that apply to all items equally.
+ *                   To target a specific item, check $item_id inside the callback.
+ * Hook/Filter:      commonsbooking_after_item-single
+ * CB Version:       2.10.8+
+ * Tested up to:     2.10.10
+ * Author:           CommonsBooking contributors
+ * License:          GPL-2.0+
+ */
+
+/**
+ * Render a custom notice after the item-single template.
+ *
+ * @param int                        $item_id The item post ID.
+ * @param \CommonsBooking\Model\Item $item    The item model instance.
+ */
+function myplugin_cb_after_item_single_notice( $item_id, $item ) {
+    ?>
+    <div class="cb-custom-notice" style="margin-top:1.5em;padding:12px 16px;border-left:4px solid #e6a817;background:#fdf6e3;">
+        <strong><?php esc_html_e( 'Please note', 'commonsbooking' ); ?>:</strong>
+        <?php esc_html_e( 'Return the item by 18:00 on the last day of your booking. Late returns affect other users.', 'commonsbooking' ); ?>
+    </div>
+    <?php
+}
+add_action( 'commonsbooking_after_item-single', 'myplugin_cb_after_item_single_notice', 10, 2 );

--- a/contrib/snippets/hooks/action-location-single-after-add-opening-hours.php
+++ b/contrib/snippets/hooks/action-location-single-after-add-opening-hours.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Snippet Title:    Display custom opening hours below a location page
+ * Description:      Reads an optional custom field "_cb_opening_hours" from
+ *                   the location post and renders it below the location-single
+ *                   template. Add the field via a custom plugin (e.g. ACF or
+ *                   CMB2) or CommonsBooking's own commonsbooking_custom_metadata
+ *                   filter. Falls back silently when the field is empty.
+ * Hook/Filter:      commonsbooking_after_location-single
+ * CB Version:       2.10.8+
+ * Tested up to:     2.10.10
+ * Author:           CommonsBooking contributors
+ * License:          GPL-2.0+
+ */
+
+/**
+ * Render opening hours below the location-single template.
+ *
+ * @param int                            $location_id The location post ID.
+ * @param \CommonsBooking\Model\Location $location    The location model instance.
+ */
+function myplugin_cb_after_location_single_opening_hours( $location_id, $location ) {
+    $opening_hours = get_post_meta( $location_id, '_cb_opening_hours', true );
+
+    if ( empty( $opening_hours ) ) {
+        return;
+    }
+    ?>
+    <div class="cb-opening-hours" style="margin-top:1.5em;">
+        <h3><?php esc_html_e( 'Opening hours', 'commonsbooking' ); ?></h3>
+        <p><?php echo wp_kses_post( $opening_hours ); ?></p>
+    </div>
+    <?php
+}
+add_action( 'commonsbooking_after_location-single', 'myplugin_cb_after_location_single_opening_hours', 10, 2 );

--- a/contrib/snippets/shortcodes/shortcode-cb-item-availability-badge.php
+++ b/contrib/snippets/shortcodes/shortcode-cb-item-availability-badge.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Snippet Title:    [cb_item_availability_badge] — available / unavailable badge for an item
+ * Description:      Renders a small coloured badge showing whether a specific
+ *                   item is currently bookable. Useful on landing pages, item
+ *                   overview posts, or news articles that highlight a particular
+ *                   piece of equipment.
+ *
+ *                   Usage: [cb_item_availability_badge id="42"]
+ *
+ *                   Parameters:
+ *                     id (required) — the post ID of the cb_item
+ *
+ * Hook/Filter:      — (registers a new shortcode, no CB hook needed)
+ * CB Version:       2.10+
+ * Tested up to:     2.10.10
+ * Author:           CommonsBooking contributors
+ * License:          GPL-2.0+
+ */
+
+/**
+ * Render an availability badge for a given CB item.
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string HTML badge or empty string on error.
+ */
+function myplugin_cb_item_availability_badge_shortcode( $atts ) {
+    $atts = shortcode_atts( [ 'id' => 0 ], $atts, 'cb_item_availability_badge' );
+    $item_id = (int) $atts['id'];
+
+    if ( ! $item_id ) {
+        return '<!-- cb_item_availability_badge: missing id attribute -->';
+    }
+
+    $post = get_post( $item_id );
+    if ( ! $post || $post->post_type !== 'cb_item' ) {
+        return '<!-- cb_item_availability_badge: invalid item id -->';
+    }
+
+    try {
+        $item      = new \CommonsBooking\Model\Item( $item_id );
+        $bookable  = $item->isBookable();
+    } catch ( \Exception $e ) {
+        return '';
+    }
+
+    if ( $bookable ) {
+        return '<span class="cb-availability-badge cb-available" style="display:inline-block;padding:2px 10px;border-radius:3px;background:#3a7d44;color:#fff;font-size:.875em;">'
+            . esc_html__( 'Available', 'commonsbooking' )
+            . '</span>';
+    }
+
+    return '<span class="cb-availability-badge cb-unavailable" style="display:inline-block;padding:2px 10px;border-radius:3px;background:#b0200c;color:#fff;font-size:.875em;">'
+        . esc_html__( 'Not available', 'commonsbooking' )
+        . '</span>';
+}
+add_shortcode( 'cb_item_availability_badge', 'myplugin_cb_item_availability_badge_shortcode' );

--- a/contrib/snippets/shortcodes/shortcode-cb-my-next-booking.php
+++ b/contrib/snippets/shortcodes/shortcode-cb-my-next-booking.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Snippet Title:    [cb_my_next_booking] — show the current user's next booking
+ * Description:      Renders a small summary of the logged-in user's next
+ *                   confirmed booking (item name, location, pickup date/time).
+ *                   Returns nothing when the user is not logged in or has no
+ *                   upcoming confirmed bookings. Place it in a sidebar widget,
+ *                   a page header, or a member-area template.
+ *
+ *                   Usage: [cb_my_next_booking]
+ *
+ * Hook/Filter:      — (registers a new shortcode, no CB hook needed)
+ * CB Version:       2.10+
+ * Tested up to:     2.10.10
+ * Author:           CommonsBooking contributors
+ * License:          GPL-2.0+
+ */
+
+/**
+ * Render the current user's next confirmed booking.
+ *
+ * @return string HTML output or empty string.
+ */
+function myplugin_cb_my_next_booking_shortcode() {
+    if ( ! is_user_logged_in() ) {
+        return '';
+    }
+
+    // Fetch confirmed bookings for the current user from today onwards.
+    $bookings = \CommonsBooking\Repository\Booking::getForCurrentUser(
+        true,                  // $asModel — return Model\Booking objects
+        strtotime( 'today' ),  // $startDate — only future / ongoing bookings
+        [ 'confirmed' ]        // $postStatus
+    );
+
+    if ( empty( $bookings ) ) {
+        return '';
+    }
+
+    // Sort ascending by start date and take the earliest.
+    usort( $bookings, fn( $a, $b ) => $a->getStartDate() - $b->getStartDate() );
+    $next = $bookings[0];
+
+    $item     = $next->getItem();
+    $location = $next->getLocation();
+
+    ob_start();
+    ?>
+    <div class="cb-my-next-booking">
+        <strong><?php esc_html_e( 'Your next booking', 'commonsbooking' ); ?>:</strong>
+        <?php if ( $item ) : ?>
+            <span class="cb-mnb-item"><?php echo esc_html( $item->getPost()->post_title ); ?></span>
+        <?php endif; ?>
+        <?php if ( $location ) : ?>
+            &mdash; <span class="cb-mnb-location"><?php echo esc_html( $location->getPost()->post_title ); ?></span>
+        <?php endif; ?>
+        &mdash; <span class="cb-mnb-date"><?php echo esc_html( $next->pickupDatetime() ); ?></span>
+        <a href="<?php echo esc_url( $next->bookingLinkUrl() ); ?>">
+            <?php esc_html_e( 'Details', 'commonsbooking' ); ?>
+        </a>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode( 'cb_my_next_booking', 'myplugin_cb_my_next_booking_shortcode' );

--- a/docs/en/documentation/advanced-functionality/hooks-and-filters.md
+++ b/docs/en/documentation/advanced-functionality/hooks-and-filters.md
@@ -156,6 +156,13 @@ add_filter('commonsbooking_tag_cb_item_yourFunction', function( $value, $obj) {
 }, 10, 2);
 ```
 
+## Community snippet library
+
+Ready-to-paste examples for all of the hooks and filters above are maintained
+in [`contrib/`](../../../../contrib/README.md) — the community snippet library.
+Copy a snippet into your Code Snippets plugin or `functions.php` to get started
+without writing code from scratch.
+
 ### Filter `commonsbooking_mobile_calendar_month_count`
 
 ::: tip Since version 2.10.5

--- a/docs/en/documentation/advanced-functionality/index.md
+++ b/docs/en/documentation/advanced-functionality/index.md
@@ -5,3 +5,4 @@
   * [Configure cache](cache)
   * [Change default values for timeframe creation](change-timeframe-creation-defaults)
   * [Hooks and filters](hooks-and-filters)
+  * [Community snippets](https://github.com/wielebenwir/commonsbooking/tree/master/contrib) — ready-to-paste PHP customizations using CB hooks and filters

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,10 @@ CommonsBooking was developed for the ["Commons Cargobike" movement](http://commo
 * [Bug-Tracker](https://github.com/wielebenwir/commonsbooking/issues)
 * [Support](https://commonsbooking.org/contact/)
 
+### How can I customize CommonsBooking with my own code?
+
+CommonsBooking exposes a set of action hooks, filter hooks, and shortcode APIs that let you extend the plugin without modifying its files. Ready-to-paste PHP snippets for common customizations are collected in the [community snippet library](https://github.com/wielebenwir/commonsbooking/tree/master/contrib) on GitHub. Copy a snippet into a [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/) or your theme's `functions.php` to get started. For a full reference of available hooks and filters, see the [developer documentation](https://commonsbooking.org/documentation).
+
 
 ## Screenshots
 


### PR DESCRIPTION
Introduces a developer-facing community snippet library for
CommonsBooking customizations via hooks, filters, shortcodes,
and integrations — without requiring changes to the core plugin.

Structure:
- contrib/README.md           – usage guide + snippet index table
- contrib/CONTRIBUTING.md     – step-by-step contribution guide with
                                file naming conventions, header spec,
                                and security checklist
- contrib/LICENSE             – GPL-2.0+
- contrib/_TEMPLATE.php       – copy-and-fill boilerplate for new snippets
- contrib/futureplan.md       – non-MVP ideas parked for later
- contrib/snippets/filters/   – example: append text to booking emails
                                (commonsbooking_mail_body)
- contrib/snippets/hooks/     – example: show user info before booking
                                single view (commonsbooking_before_booking-single)
- contrib/snippets/shortcodes/  – placeholder directory
- contrib/snippets/integrations/ – placeholder directory
- contrib/mini-plugins/       – placeholder for full WP plugin packages

Also:
- .distignore: exclude /contrib/ from WordPress.org release zips
- docs/en/…/hooks-and-filters.md: cross-link to the snippet library

https://claude.ai/code/session_013c6PDm8r9LqnAqF3enh4aV