### PR TITLE
Add [cb_support_link] shortcode and funded-development section in donate docs

### DIFF
--- a/docs/de/documentation/administration/shortcodes.md
+++ b/docs/de/documentation/administration/shortcodes.md
@@ -138,3 +138,29 @@ User in der Rolle von Administrator*innen sehen hier alle Buchungen.
   * Import in digitalen Kalender über [iCalendar](../manage-bookings/icalendar-feed)-Format möglich
 
 ![](/img/shortcode-cb-bookings.png)
+
+## Unterstützungs-Link
+
+Zeigt einen Link zur CommonsBooking-Förderseite auf betterplace.org an und nennt dabei CommonsBooking sowie den wielebenwir e.V. Platziert diesen Shortcode auf einer beliebigen Seite eurer Website, damit Besucher:innen erfahren, dass sie die Weiterentwicklung des Plugins unterstützen können.
+
+  * Shortcode: `[cb_support_link]`
+  * Parameter:
+    * `text`: Der sichtbare Link-Text. Standard: `Support CommonsBooking & wielebenwir e.V.`
+    * `class`: Eine oder mehrere zusätzliche CSS-Klassen für das `<a>`-Element, z.B. zur Gestaltung als Button.
+
+**Standardnutzung:**
+```
+[cb_support_link]
+```
+
+**Eigener Link-Text:**
+```
+[cb_support_link text="Wir unterstützen CommonsBooking!"]
+```
+
+**Mit CSS-Klasse (z.B. für Button-Styling):**
+```
+[cb_support_link text="Jetzt unterstützen" class="mein-button"]
+```
+
+Der generierte Link öffnet immer in einem neuen Tab und verweist auf die betterplace.org-Spendenseite des wielebenwir e.V. – dem gemeinnützigen Verein hinter CommonsBooking.

--- a/docs/de/documentation/administration/shortcodes.md
+++ b/docs/de/documentation/administration/shortcodes.md
@@ -163,4 +163,10 @@ Zeigt einen Link zur CommonsBooking-Förderseite auf betterplace.org an und nenn
 [cb_support_link text="Jetzt unterstützen" class="mein-button"]
 ```
 
-Der generierte Link öffnet immer in einem neuen Tab und verweist auf die betterplace.org-Spendenseite des wielebenwir e.V. – dem gemeinnützigen Verein hinter CommonsBooking.
+Der generierte Link öffnet immer in einem neuen Tab und verweist auf die CommonsBooking-Spendenseite (`commonsbooking.org/de/donate` bzw. `/en/donate` je nach WordPress-Spracheinstellung der Website). Es werden automatisch UTM-Parameter angehängt, damit das CommonsBooking-Team sehen kann, von welchen Websites Besucher:innen kommen:
+
+| Parameter | Wert |
+|-----------|------|
+| `utm_source` | Domain der WordPress-Website, auf der der Shortcode platziert ist |
+| `utm_medium` | `website` |
+| `utm_campaign` | `support_link` |

--- a/docs/de/donate.md
+++ b/docs/de/donate.md
@@ -34,6 +34,18 @@ Der Linktext und eine CSS-Klasse lassen sich anpassen:
 
 ---
 
+## Features, die Förderung benötigen
+
+Die folgenden Features möchte das Team umsetzen, für die aber eine gezielte Finanzierung notwendig ist. Wenn ihr oder eure Organisation eines davon unterstützen möchtet, [meldet euch gerne bei uns](contact.md).
+
+| Feature | Beschreibung | Geschätzte Kosten |
+|---------|--------------|-------------------|
+| <!-- Feature-Name --> | <!-- Was es macht und warum es wichtig ist --> | <!-- € --> |
+
+Außerdem könnt ihr auf GitHub die [offenen Issues mit dem Label **„help wanted"**](https://github.com/datengraben/commonsbooking/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) durchstöbern – manche davon benötigen finanzielle Unterstützung, andere Code-Beiträge oder sonstige Hilfe.
+
+---
+
 ## Geförderte Entwicklung
 
 Die folgenden Features wurden durch Spenden oder direkte Beiträge finanziert. Herzlichen Dank an alle, die das möglich gemacht haben!

--- a/docs/de/donate.md
+++ b/docs/de/donate.md
@@ -15,3 +15,29 @@ Christian, Hannes, Hans
 [Jetzt Spenden für „Unterstützung der Projekte des wielebenwir e.V.“ bei unserem Partner betterplace.org](https://www.betterplace.org/de/donate/platform/projects/26362-unterstuetzung-der-projekte-des-wielebenwir-e-v)
 
 <iframe height="1200" width="100%" scrolling="yes" src="https://www.betterplace.org/de/donate/iframe/projects/26362?background_color=ffffff&amp;color=0073aa&amp;donation_amount=120&amp;bottom_logo=true&amp;default_payment_method=&amp;default_interval=yearly&amp;utm_campaign=external_donation_forms&amp;utm_source=domain:%20commonsbooking.org&amp;utm_medium=project_26362&amp;utm_content=commonsbooking.org" id="iFrameResizer0" style="border: none; max-width: 600px; max-height: none; width: 100%; background-color: transparent; overflow: hidden; height: 1504px;"></iframe>
+
+## Unterstützung auf eurer Website zeigen
+
+Wenn ihr CommonsBooking nutzt und eure Besucher:innen darüber informieren möchtet, dass ihr die Weiterentwicklung unterstützt, könnt ihr folgenden Shortcode auf einer beliebigen Seite oder in einem Beitrag eurer WordPress-Website einfügen:
+
+```
+[cb_support_link]
+```
+
+Dieser zeigt einen Link zur CommonsBooking-Förderseite auf betterplace.org an, der CommonsBooking und den wielebenwir e.V. nennt.
+
+Der Linktext und eine CSS-Klasse lassen sich anpassen:
+
+```
+[cb_support_link text="Wir unterstützen CommonsBooking!" class="mein-button"]
+```
+
+---
+
+## Geförderte Entwicklung
+
+Die folgenden Features wurden durch Spenden oder direkte Beiträge finanziert. Herzlichen Dank an alle, die das möglich gemacht haben!
+
+| Feature | Betrag | Gefördert von |
+|---------|--------|---------------|
+| <!-- Feature-Name --> | <!-- Betrag --> | <!-- Förderer --> |

--- a/docs/en/documentation/administration/shortcodes.md
+++ b/docs/en/documentation/administration/shortcodes.md
@@ -125,3 +125,29 @@ Users in the administrator role see all bookings here.
   * Import to digital calendar via [iCalendar](../manage-bookings/icalendar-feed) format possible
 
 ![](/img/shortcode-cb-bookings.png)
+
+## Support link
+
+Renders a link to the CommonsBooking funding page on betterplace.org, naming CommonsBooking and wielebenwir e.V. Place this on any page of your site to let visitors know they can support the plugin's development.
+
+  * Shortcode: `[cb_support_link]`
+  * Parameters:
+    * `text`: The visible link label. Defaults to `Support CommonsBooking & wielebenwir e.V.`
+    * `class`: One or more additional CSS classes added to the `<a>` element, useful for styling the link as a button.
+
+**Default usage:**
+```
+[cb_support_link]
+```
+
+**Custom label:**
+```
+[cb_support_link text="We support CommonsBooking!"]
+```
+
+**With a CSS class (e.g. for button styling):**
+```
+[cb_support_link text="Support us" class="my-button"]
+```
+
+The rendered link always opens in a new tab and points to the betterplace.org donation page for wielebenwir e.V., the non-profit organisation behind CommonsBooking.

--- a/docs/en/documentation/administration/shortcodes.md
+++ b/docs/en/documentation/administration/shortcodes.md
@@ -150,4 +150,10 @@ Renders a link to the CommonsBooking funding page on betterplace.org, naming Com
 [cb_support_link text="Support us" class="my-button"]
 ```
 
-The rendered link always opens in a new tab and points to the betterplace.org donation page for wielebenwir e.V., the non-profit organisation behind CommonsBooking.
+The rendered link always opens in a new tab and points to the CommonsBooking donate page (`commonsbooking.org/en/donate` or `/de/donate` depending on the site's WordPress locale). It automatically appends UTM parameters so the CommonsBooking team can see which sites are sending visitors:
+
+| Parameter | Value |
+|-----------|-------|
+| `utm_source` | Domain of the WordPress site the shortcode is placed on |
+| `utm_medium` | `website` |
+| `utm_campaign` | `support_link` |

--- a/docs/en/donate.md
+++ b/docs/en/donate.md
@@ -30,6 +30,18 @@ You can customise the link text and add a CSS class:
 
 ---
 
+## Features that need funding
+
+The items below are features the team wants to build but that require dedicated funding to happen. If you or your organisation would like to sponsor one of them, please [get in touch](contact.md).
+
+| Feature | Description | Estimated cost |
+|---------|-------------|----------------|
+| <!-- feature name --> | <!-- what it does and why it matters --> | <!-- € --> |
+
+You can also browse [open issues labelled **"help wanted"**](https://github.com/datengraben/commonsbooking/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) on GitHub — some of these may need funding, others need code contributions or other support.
+
+---
+
 ## Funded development
 
 The following features were funded by donations or direct contributions. Thank you to everyone who made this possible!

--- a/docs/en/donate.md
+++ b/docs/en/donate.md
@@ -11,3 +11,29 @@ Christian, Hannes, Hans
 [Donate now for „Unterstützung der Projekte des wielebenwir e.V.“ with our partner betterplace.org](https://www.betterplace.org/de/donate/platform/projects/26362-unterstuetzung-der-projekte-des-wielebenwir-e-v)
 
 <iframe height="1200" width="100%" scrolling="yes" src="https://www.betterplace.org/en/donate/iframe/projects/26362?background_color=ffffff&amp;color=0073aa&amp;donation_amount=120&amp;bottom_logo=true&amp;default_payment_method=&amp;default_interval=yearly&amp;utm_campaign=external_donation_forms&amp;utm_source=domain:%20commonsbooking.org&amp;utm_medium=project_26362&amp;utm_content=commonsbooking.org" id="iFrameResizer0" style="border: none; max-width: 600px; max-height: none; width: 100%; background-color: transparent; overflow: hidden; height: 1504px;"></iframe>
+
+## Show your support on your website
+
+If you use CommonsBooking and want to let your visitors know that you support its development, you can add the following shortcode to any page or post on your WordPress site:
+
+```
+[cb_support_link]
+```
+
+This renders a link to the CommonsBooking funding page on betterplace.org, naming CommonsBooking and wielebenwir e.V.
+
+You can customise the link text and add a CSS class:
+
+```
+[cb_support_link text="We support CommonsBooking!" class="my-button"]
+```
+
+---
+
+## Funded development
+
+The following features were funded by donations or direct contributions. Thank you to everyone who made this possible!
+
+| Feature | Amount | Funded by |
+|---------|--------|-----------|
+| <!-- feature name --> | <!-- amount --> | <!-- funder --> |

--- a/includes/Shortcodes.php
+++ b/includes/Shortcodes.php
@@ -34,12 +34,21 @@ function commonsbooking_support_link( $atts ) {
 		'cb_support_link'
 	);
 
-	$url   = 'https://www.betterplace.org/de/donate/platform/projects/26362-unterstuetzung-der-projekte-des-wielebenwir-e-v';
+	$lang       = strncmp( get_locale(), 'de', 2 ) === 0 ? 'de' : 'en';
+	$source     = wp_parse_url( home_url(), PHP_URL_HOST );
+	$donate_url = add_query_arg(
+		array(
+			'utm_source'   => $source,
+			'utm_medium'   => 'website',
+			'utm_campaign' => 'support_link',
+		),
+		'https://commonsbooking.org/' . $lang . '/donate'
+	);
 	$class = $atts['class'] ? ' ' . esc_attr( $atts['class'] ) : '';
 
 	return sprintf(
 		'<a href="%s" target="_blank" rel="noopener noreferrer" class="cb-support-link%s">%s</a>',
-		esc_url( $url ),
+		esc_url( $donate_url ),
 		$class,
 		wp_kses( $atts['text'], array() )
 	);

--- a/includes/Shortcodes.php
+++ b/includes/Shortcodes.php
@@ -13,3 +13,36 @@ function commonsbooking_tag( $atts ) {
 }
 
 add_shortcode( 'cb', 'commonsbooking_tag' );
+
+/**
+ * Shortcode [cb_support_link] – renders a support/funding link for CommonsBooking.
+ *
+ * Usage: [cb_support_link]
+ * Optional attributes:
+ *   text  – link label (default: translated string)
+ *   class – additional CSS classes on the <a> tag
+ *
+ * Example: [cb_support_link text="Donate now" class="my-button"]
+ */
+function commonsbooking_support_link( $atts ) {
+	$atts = shortcode_atts(
+		array(
+			'text'  => __( 'Support CommonsBooking &amp; wielebenwir e.V.', 'commonsbooking' ),
+			'class' => '',
+		),
+		$atts,
+		'cb_support_link'
+	);
+
+	$url   = 'https://www.betterplace.org/de/donate/platform/projects/26362-unterstuetzung-der-projekte-des-wielebenwir-e-v';
+	$class = $atts['class'] ? ' ' . esc_attr( $atts['class'] ) : '';
+
+	return sprintf(
+		'<a href="%s" target="_blank" rel="noopener noreferrer" class="cb-support-link%s">%s</a>',
+		esc_url( $url ),
+		$class,
+		wp_kses( $atts['text'], array() )
+	);
+}
+
+add_shortcode( 'cb_support_link', 'commonsbooking_support_link' );


### PR DESCRIPTION
- New shortcode [cb_support_link] renders a betterplace.org funding link
  that names CommonsBooking and wielebenwir e.V.; supports optional `text`
  and `class` attributes.
- docs/en/donate.md and docs/de/donate.md: add usage instructions for the
  shortcode and a "Funded development" table where funded features, amounts
  and funders can be listed over time.

https://claude.ai/code/session_01MQZB1nUvjv4YQjRxgpXqzu