### PR TITLE
Add red-phase snapshot tests for REST and admin AJAX APIs

### DIFF
--- a/tests/php/API/ApiSnapshotTrait.php
+++ b/tests/php/API/ApiSnapshotTrait.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace CommonsBooking\Tests\API;
+
+/**
+ * Golden-master snapshot assertions for API tests.
+ *
+ * Workflow:
+ *   1. First test run: no fixture file exists → response is captured and saved.
+ *      The test is marked as incomplete ("fixture generated").
+ *   2. Subsequent runs: live response is normalized and compared against the
+ *      saved fixture. Any shape change turns the test Red.
+ *   3. To regenerate a fixture, delete the corresponding file and re-run.
+ *
+ * Normalization map (caller-supplied):
+ *   [(string)$postId => 'POST_PLACEHOLDER', ...]
+ *
+ * Auto-normalizations applied to every response string value:
+ *   - ISO-8601 timestamps  → "TIMESTAMP"
+ *   - get_rest_url() value → "REST_URL/"
+ *   - get_bloginfo('url')  → "SITE_URL"
+ */
+trait ApiSnapshotTrait {
+
+	/**
+	 * Directory that holds fixture files.
+	 * Override in a test class if the trait is used outside tests/php/API/.
+	 */
+	protected static string $fixtureDir = __DIR__ . '/Fixtures';
+
+	// -------------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Load and JSON-decode a fixture file.
+	 *
+	 * @param string $name Filename inside $fixtureDir (e.g. 'rest-items.json')
+	 */
+	public function loadFixture( string $name ): mixed {
+		$path = static::$fixtureDir . '/' . $name;
+		$this->assertFileExists( $path, "Fixture file not found: $path" );
+		$contents = file_get_contents( $path );
+		$decoded  = json_decode( $contents, true );
+		$this->assertNotNull( $decoded, "Fixture '$name' contains invalid JSON." );
+		return $decoded;
+	}
+
+	/**
+	 * Recursively replace dynamic values in $data with stable placeholders.
+	 *
+	 * @param mixed $data            Any PHP value (array, object, string, scalar)
+	 * @param array $normalizationMap Additional replacements: [original => placeholder]
+	 */
+	public function normalizeForComparison( mixed $data, array $normalizationMap = [] ): mixed {
+		if ( is_array( $data ) ) {
+			$result = [];
+			foreach ( $data as $key => $value ) {
+				$result[ $key ] = $this->normalizeForComparison( $value, $normalizationMap );
+			}
+			return $result;
+		}
+
+		if ( is_object( $data ) ) {
+			$result = [];
+			foreach ( get_object_vars( $data ) as $key => $value ) {
+				$result[ $key ] = $this->normalizeForComparison( $value, $normalizationMap );
+			}
+			return $result;
+		}
+
+		if ( is_string( $data ) ) {
+			// Caller-supplied dynamic IDs / URLs.
+			foreach ( $normalizationMap as $original => $placeholder ) {
+				$data = str_replace( (string) $original, (string) $placeholder, $data );
+			}
+
+			// ISO-8601 timestamps (e.g. last_updated, last_reported, availability slots).
+			$data = preg_replace(
+				'/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+\-]\d{2}:\d{2}/',
+				'TIMESTAMP',
+				$data
+			);
+
+			// REST namespace URL prefix.
+			$restUrl = rtrim( get_rest_url(), '/' ) . '/';
+			if ( $restUrl !== '/' ) {
+				$data = str_replace( $restUrl, 'REST_URL/', $data );
+			}
+
+			// Site URL.
+			$siteUrl = get_bloginfo( 'url' );
+			if ( $siteUrl ) {
+				$data = str_replace( $siteUrl, 'SITE_URL', $data );
+			}
+
+			return $data;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Assert live response matches stored fixture.
+	 *
+	 * On first call (no fixture file): saves the normalized response as the
+	 * fixture and marks the test as incomplete so the developer knows to review
+	 * and commit the generated file.
+	 *
+	 * @param string $fixtureName    Filename inside $fixtureDir (e.g. 'rest-items.json')
+	 * @param mixed  $responseData   Raw API response (object, array, or scalar)
+	 * @param array  $normalizationMap Dynamic-value replacements: [original => placeholder]
+	 */
+	public function assertMatchesApiFixture(
+		string $fixtureName,
+		mixed $responseData,
+		array $normalizationMap = []
+	): void {
+		$path   = static::$fixtureDir . '/' . $fixtureName;
+		$actual = $this->normalizeForComparison( $responseData, $normalizationMap );
+
+		if ( ! file_exists( $path ) ) {
+			$this->generateFixture( $path, $actual );
+			$this->markTestIncomplete(
+				"Fixture '$fixtureName' was generated. Review it and re-run the tests."
+			);
+			return;
+		}
+
+		$expected = $this->loadFixture( $fixtureName );
+		$this->assertEquals(
+			$expected,
+			$actual,
+			"API response does not match fixture '$fixtureName'.\n" .
+			"If the change is intentional, delete the fixture file and re-run to regenerate."
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Internal helpers
+	// -------------------------------------------------------------------------
+
+	private function generateFixture( string $path, mixed $data ): void {
+		$dir = dirname( $path );
+		if ( ! is_dir( $dir ) ) {
+			mkdir( $dir, 0755, true );
+		}
+		file_put_contents(
+			$path,
+			json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES )
+		);
+	}
+}

--- a/tests/php/API/AvailabilityRouteSnapshotTest.php
+++ b/tests/php/API/AvailabilityRouteSnapshotTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace CommonsBooking\Tests\API;
+
+use SlopeIt\ClockMock\ClockMock;
+
+/**
+ * Snapshot test for GET /commonsbooking/v1/availability
+ */
+class AvailabilityRouteSnapshotTest extends CB_REST_Route_UnitTestCase {
+
+	use ApiSnapshotTrait;
+
+	protected $ENDPOINT = '/commonsbooking/v1/availability';
+
+	public function setUp(): void {
+		parent::setUp();
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$this->locationId = $this->createLocation( 'Test Location', 'publish' );
+		$this->itemId     = $this->createItem( 'Test Item', 'publish' );
+
+		$start = ( new \DateTimeImmutable( self::CURRENT_DATE ) )->modify( '-1 day' )->getTimestamp();
+		$end   = ( new \DateTimeImmutable( self::CURRENT_DATE ) )->modify( '+1 day' )->getTimestamp();
+
+		$this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			$start,
+			$end,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			'on',
+			'd'
+		);
+
+		ClockMock::reset();
+	}
+
+	public function testAvailabilityResponseMatchesFixture(): void {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$normalizationMap = [
+			(string) $this->itemId     => 'ITEM_ID',
+			(string) $this->locationId => 'LOCATION_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'rest-availability.json', $response->get_data(), $normalizationMap );
+
+		ClockMock::reset();
+	}
+
+	public function testSingleItemAvailabilityMatchesFixture(): void {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT . '/' . $this->itemId );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$normalizationMap = [
+			(string) $this->itemId     => 'ITEM_ID',
+			(string) $this->locationId => 'LOCATION_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'rest-availability-single.json', $response->get_data(), $normalizationMap );
+
+		ClockMock::reset();
+	}
+}

--- a/tests/php/API/GBFS/DiscoveryRouteSnapshotTest.php
+++ b/tests/php/API/GBFS/DiscoveryRouteSnapshotTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CommonsBooking\Tests\API\GBFS;
+
+use CommonsBooking\Tests\API\CB_REST_Route_UnitTestCase;
+use CommonsBooking\Tests\API\ApiSnapshotTrait;
+
+/**
+ * Snapshot test for GET /commonsbooking/v1/gbfs.json
+ */
+class DiscoveryRouteSnapshotTest extends CB_REST_Route_UnitTestCase {
+
+	use ApiSnapshotTrait;
+
+	protected $ENDPOINT = '/commonsbooking/v1/gbfs.json';
+
+	public function testDiscoveryResponseMatchesFixture(): void {
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertMatchesApiFixture( 'rest-gbfs-discovery.json', $response->get_data() );
+	}
+}

--- a/tests/php/API/GBFS/StationInformationRouteSnapshotTest.php
+++ b/tests/php/API/GBFS/StationInformationRouteSnapshotTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CommonsBooking\Tests\API\GBFS;
+
+use CommonsBooking\Tests\API\CB_REST_Route_UnitTestCase;
+use CommonsBooking\Tests\API\ApiSnapshotTrait;
+
+/**
+ * Snapshot test for GET /commonsbooking/v1/station_information.json
+ */
+class StationInformationRouteSnapshotTest extends CB_REST_Route_UnitTestCase {
+
+	use ApiSnapshotTrait;
+
+	protected $ENDPOINT = '/commonsbooking/v1/station_information.json';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->locationId = $this->createLocation( 'Test Location', 'publish' );
+		// Provide coordinates to avoid geocoding calls during the test.
+		update_post_meta( $this->locationId, 'geo_latitude', '51.5' );
+		update_post_meta( $this->locationId, 'geo_longitude', '9.0' );
+	}
+
+	public function testStationInformationResponseMatchesFixture(): void {
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$normalizationMap = [
+			(string) $this->locationId => 'LOCATION_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'rest-gbfs-station-information.json', $response->get_data(), $normalizationMap );
+	}
+}

--- a/tests/php/API/GBFS/StationStatusRouteSnapshotTest.php
+++ b/tests/php/API/GBFS/StationStatusRouteSnapshotTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CommonsBooking\Tests\API\GBFS;
+
+use CommonsBooking\Tests\API\CB_REST_Route_UnitTestCase;
+use CommonsBooking\Tests\API\ApiSnapshotTrait;
+use SlopeIt\ClockMock\ClockMock;
+
+/**
+ * Snapshot test for GET /commonsbooking/v1/station_status.json
+ */
+class StationStatusRouteSnapshotTest extends CB_REST_Route_UnitTestCase {
+
+	use ApiSnapshotTrait;
+
+	protected $ENDPOINT = '/commonsbooking/v1/station_status.json';
+
+	public function setUp(): void {
+		parent::setUp();
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$this->locationId = $this->createLocation( 'Test Location', 'publish' );
+		update_post_meta( $this->locationId, 'geo_latitude', '51.5' );
+		update_post_meta( $this->locationId, 'geo_longitude', '9.0' );
+
+		$this->itemId = $this->createItem( 'Test Item', 'publish' );
+
+		// Timeframe covers CURRENT_DATE so the item is available right now.
+		$start = ( new \DateTimeImmutable( self::CURRENT_DATE ) )->modify( '-1 day' )->getTimestamp();
+		$end   = ( new \DateTimeImmutable( self::CURRENT_DATE ) )->modify( '+1 day' )->getTimestamp();
+
+		$this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			$start,
+			$end,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			'on',
+			'd'
+		);
+
+		ClockMock::reset();
+	}
+
+	public function tearDown(): void {
+		ClockMock::reset();
+		parent::tearDown();
+	}
+
+	public function testStationStatusResponseMatchesFixture(): void {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$normalizationMap = [
+			(string) $this->locationId => 'LOCATION_ID',
+			(string) $this->itemId     => 'ITEM_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'rest-gbfs-station-status.json', $response->get_data(), $normalizationMap );
+
+		ClockMock::reset();
+	}
+}

--- a/tests/php/API/GBFS/SystemInformationRouteSnapshotTest.php
+++ b/tests/php/API/GBFS/SystemInformationRouteSnapshotTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CommonsBooking\Tests\API\GBFS;
+
+use CommonsBooking\Tests\API\CB_REST_Route_UnitTestCase;
+use CommonsBooking\Tests\API\ApiSnapshotTrait;
+
+/**
+ * Snapshot test for GET /commonsbooking/v1/system_information.json
+ */
+class SystemInformationRouteSnapshotTest extends CB_REST_Route_UnitTestCase {
+
+	use ApiSnapshotTrait;
+
+	protected $ENDPOINT = '/commonsbooking/v1/system_information.json';
+
+	public function testSystemInformationResponseMatchesFixture(): void {
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertMatchesApiFixture( 'rest-gbfs-system-information.json', $response->get_data() );
+	}
+}

--- a/tests/php/API/ItemsRouteSnapshotTest.php
+++ b/tests/php/API/ItemsRouteSnapshotTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace CommonsBooking\Tests\API;
+
+use SlopeIt\ClockMock\ClockMock;
+
+/**
+ * Snapshot test for GET /commonsbooking/v1/items
+ *
+ * On first run the fixture is generated from the live response and the test is
+ * marked incomplete.  On every subsequent run the live response is compared
+ * against the stored fixture so any unintentional shape change turns the test Red.
+ */
+class ItemsRouteSnapshotTest extends CB_REST_Route_UnitTestCase {
+
+	use ApiSnapshotTrait;
+
+	protected $ENDPOINT = '/commonsbooking/v1/items';
+
+	public function setUp(): void {
+		parent::setUp();
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$this->locationId = $this->createLocation( 'Test Location', 'publish' );
+		update_post_meta( $this->locationId, 'geo_latitude', '51.5' );
+		update_post_meta( $this->locationId, 'geo_longitude', '9.0' );
+
+		$this->itemId = $this->createItem( 'Test Item', 'publish' );
+
+		$start = ( new \DateTimeImmutable( self::CURRENT_DATE ) )->modify( '-1 day' )->getTimestamp();
+		$end   = ( new \DateTimeImmutable( self::CURRENT_DATE ) )->modify( '+1 day' )->getTimestamp();
+
+		$this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			$start,
+			$end,
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::BOOKABLE_ID,
+			'on',
+			'd'
+		);
+	}
+
+	public function tearDown(): void {
+		ClockMock::reset();
+		parent::tearDown();
+	}
+
+	public function testItemsResponseMatchesFixture(): void {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$normalizationMap = [
+			(string) $this->itemId     => 'ITEM_ID',
+			(string) $this->locationId => 'LOCATION_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'rest-items.json', $response->get_data(), $normalizationMap );
+
+		ClockMock::reset();
+	}
+
+	public function testSingleItemResponseMatchesFixture(): void {
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT . '/' . $this->itemId );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$normalizationMap = [
+			(string) $this->itemId     => 'ITEM_ID',
+			(string) $this->locationId => 'LOCATION_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'rest-items-single.json', $response->get_data(), $normalizationMap );
+
+		ClockMock::reset();
+	}
+}

--- a/tests/php/API/LocationsRouteSnapshotTest.php
+++ b/tests/php/API/LocationsRouteSnapshotTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CommonsBooking\Tests\API;
+
+use SlopeIt\ClockMock\ClockMock;
+
+/**
+ * Snapshot test for GET /commonsbooking/v1/locations
+ */
+class LocationsRouteSnapshotTest extends CB_REST_Route_UnitTestCase {
+
+	use ApiSnapshotTrait;
+
+	protected $ENDPOINT = '/commonsbooking/v1/locations';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->locationId = $this->createLocation( 'Test Location', 'publish' );
+		update_post_meta( $this->locationId, 'geo_latitude', '51.5' );
+		update_post_meta( $this->locationId, 'geo_longitude', '9.0' );
+	}
+
+	public function testLocationsResponseMatchesFixture(): void {
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$normalizationMap = [
+			(string) $this->locationId => 'LOCATION_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'rest-locations.json', $response->get_data(), $normalizationMap );
+	}
+
+	public function testSingleLocationResponseMatchesFixture(): void {
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT . '/' . $this->locationId );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$normalizationMap = [
+			(string) $this->locationId => 'LOCATION_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'rest-locations-single.json', $response->get_data(), $normalizationMap );
+	}
+}

--- a/tests/php/API/ProjectsRouteSnapshotTest.php
+++ b/tests/php/API/ProjectsRouteSnapshotTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CommonsBooking\Tests\API;
+
+/**
+ * Snapshot test for GET /commonsbooking/v1/projects
+ */
+class ProjectsRouteSnapshotTest extends CB_REST_Route_UnitTestCase {
+
+	use ApiSnapshotTrait;
+
+	protected $ENDPOINT = '/commonsbooking/v1/projects';
+
+	public function testProjectsResponseMatchesFixture(): void {
+		$request  = new \WP_REST_Request( 'GET', $this->ENDPOINT );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertMatchesApiFixture( 'rest-projects.json', $response->get_data() );
+	}
+}

--- a/tests/php/View/BookingAjaxSnapshotTest.php
+++ b/tests/php/View/BookingAjaxSnapshotTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace CommonsBooking\Tests\View;
+
+use CommonsBooking\Settings\Settings;
+use CommonsBooking\Tests\API\ApiSnapshotTrait;
+use CommonsBooking\Tests\Wordpress\CustomPostType_AJAX_Test;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use CommonsBooking\Wordpress\CustomPostType\Timeframe;
+use SlopeIt\ClockMock\ClockMock;
+
+/**
+ * Snapshot tests for booking-form AJAX endpoints.
+ *
+ * Covers:
+ *   - cb_get_bookable_location  → View\Booking::getLocationForItem_AJAX()
+ *   - cb_get_booking_code       → View\Booking::getBookingCode_AJAX()
+ */
+class BookingAjaxSnapshotTest extends CustomPostType_AJAX_Test {
+
+	use ApiSnapshotTrait;
+
+	protected static string $fixtureDir = __DIR__ . '/../API/Fixtures';
+
+	protected $hooks = [
+		'cb_get_bookable_location' => [
+			\CommonsBooking\View\Booking::class,
+			'getLocationForItem_AJAX',
+		],
+		'cb_get_booking_code' => [
+			\CommonsBooking\View\Booking::class,
+			'getBookingCode_AJAX',
+		],
+	];
+
+	private array $bookingCodes = [ 'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot' ];
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$codesString = implode( ',', $this->bookingCodes );
+		Settings::updateOption( 'commonsbooking_options_bookingcodes', 'bookingcodes', $codesString );
+		\CommonsBooking\Repository\BookingCodes::initBookingCodesTable();
+
+		ClockMock::freeze( new \DateTime( CustomPostTypeTest::CURRENT_DATE ) );
+
+		$this->createTimeframe();
+
+		// Trigger booking-code generation for the frozen date.
+		$timeframeCPT = new Timeframe();
+		$timeframeCPT->savePost( $this->timeframeID, get_post( $this->timeframeID ) );
+
+		ClockMock::reset();
+	}
+
+	public function tear_down(): void {
+		ClockMock::reset();
+		$this->tearDownBookingCodesTable();
+		parent::tear_down();
+	}
+
+	public function testGetBookableLocationResponseMatchesFixture(): void {
+		ClockMock::freeze( new \DateTime( CustomPostTypeTest::CURRENT_DATE ) );
+
+		$_POST['data'] = [ 'itemID' => $this->itemID ];
+		$response      = $this->runHook( 'cb_get_bookable_location' );
+
+		$normalizationMap = [
+			(string) $this->itemID     => 'ITEM_ID',
+			(string) $this->locationID => 'LOCATION_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'ajax-get-bookable-location.json', $response, $normalizationMap );
+
+		ClockMock::reset();
+	}
+
+	public function testGetBookingCodeResponseMatchesFixture(): void {
+		ClockMock::freeze( new \DateTime( CustomPostTypeTest::CURRENT_DATE ) );
+
+		$_POST['data'] = [
+			'itemID'     => $this->itemID,
+			'locationID' => $this->locationID,
+			'startDate'  => date( 'm/d/Y', strtotime( CustomPostTypeTest::CURRENT_DATE ) ),
+		];
+		$response = $this->runHook( 'cb_get_booking_code' );
+
+		$normalizationMap = [
+			(string) $this->itemID     => 'ITEM_ID',
+			(string) $this->locationID => 'LOCATION_ID',
+		];
+
+		// The booking code itself is one of the known codes — normalize it so
+		// the fixture doesn't depend on which code was assigned.
+		foreach ( $this->bookingCodes as $code ) {
+			$normalizationMap[ $code ] = 'BOOKING_CODE';
+		}
+
+		$this->assertMatchesApiFixture( 'ajax-get-booking-code.json', $response, $normalizationMap );
+
+		ClockMock::reset();
+	}
+
+	private function tearDownBookingCodesTable(): void {
+		global $wpdb;
+		$table = $wpdb->prefix . \CommonsBooking\Repository\BookingCodes::$tablename;
+		$wpdb->query( "DROP TABLE IF EXISTS $table" );
+	}
+}

--- a/tests/php/View/CalendarDataSnapshotTest.php
+++ b/tests/php/View/CalendarDataSnapshotTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace CommonsBooking\Tests\View;
+
+use CommonsBooking\Tests\API\ApiSnapshotTrait;
+use CommonsBooking\Tests\Wordpress\CustomPostType_AJAX_Test;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use SlopeIt\ClockMock\ClockMock;
+
+/**
+ * Snapshot test for the cb_calendar_data AJAX endpoint.
+ *
+ * Handler: CommonsBooking\View\Calendar::getCalendarData()
+ * No nonce required (nopriv handler).
+ */
+class CalendarDataSnapshotTest extends CustomPostType_AJAX_Test {
+
+	use ApiSnapshotTrait;
+
+	// Fixture files live alongside the other API fixtures.
+	protected static string $fixtureDir = __DIR__ . '/../API/Fixtures';
+
+	protected $hooks = [
+		'cb_calendar_data' => [
+			\CommonsBooking\View\Calendar::class,
+			'getCalendarData',
+		],
+	];
+
+	public function set_up(): void {
+		parent::set_up();
+		ClockMock::freeze( new \DateTime( CustomPostTypeTest::CURRENT_DATE ) );
+		$this->createTimeframe();
+		ClockMock::reset();
+	}
+
+	public function tear_down(): void {
+		ClockMock::reset();
+		parent::tear_down();
+	}
+
+	public function testCalendarDataResponseMatchesFixture(): void {
+		ClockMock::freeze( new \DateTime( CustomPostTypeTest::CURRENT_DATE ) );
+
+		$_POST['item']     = $this->itemID;
+		$_POST['location'] = $this->locationID;
+		$_POST['sd']       = CustomPostTypeTest::CURRENT_DATE;
+		$_POST['ed']       = date( 'Y-m-d', strtotime( '+2 weeks', strtotime( CustomPostTypeTest::CURRENT_DATE ) ) );
+
+		$response = $this->runHook( 'cb_calendar_data' );
+
+		$normalizationMap = [
+			(string) $this->itemID     => 'ITEM_ID',
+			(string) $this->locationID => 'LOCATION_ID',
+		];
+
+		$this->assertMatchesApiFixture( 'ajax-calendar-data.json', $response, $normalizationMap );
+
+		ClockMock::reset();
+	}
+}


### PR DESCRIPTION
Adds a golden-master snapshot testing layer so the full response shape
of every public API endpoint is locked in before refactoring begins.

Infrastructure
- `ApiSnapshotTrait`: normalises dynamic values (post IDs, timestamps,
  site/REST URLs) and compares live responses against stored JSON
  fixtures. On first run the fixture is auto-generated and the test is
  marked incomplete; from that point on any shape change turns the test
  Red.

REST snapshot tests (8 endpoints)
- ItemsRouteSnapshotTest    – list + single item
- LocationsRouteSnapshotTest – list + single location
- AvailabilityRouteSnapshotTest – all + single-item availability
- ProjectsRouteSnapshotTest – project metadata
- GBFS/DiscoveryRouteSnapshotTest
- GBFS/SystemInformationRouteSnapshotTest
- GBFS/StationInformationRouteSnapshotTest
- GBFS/StationStatusRouteSnapshotTest

Admin AJAX snapshot tests (3 actions)
- CalendarDataSnapshotTest  – cb_calendar_data
- BookingAjaxSnapshotTest   – cb_get_bookable_location + cb_get_booking_code

All tests use deterministic test data (frozen clock, fixed lat/lon) and
share a single Fixtures/ directory under tests/php/API/.

https://claude.ai/code/session_017d1QyizC3FwU7Wa1KfCSM6