### PR TITLE
Add booking statistics tracking and admin dashboard

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -17,8 +17,12 @@ use CommonsBooking\Service\iCalendar;
 use CommonsBooking\Service\Upgrade;
 use CommonsBooking\Settings\Settings;
 use CommonsBooking\Repository\BookingCodes;
+use CommonsBooking\Repository\BookingStats as BookingStatsRepo;
+use CommonsBooking\Service\BookingStats as BookingStatsService;
 use CommonsBooking\View\Dashboard;
 use CommonsBooking\View\MassOperations;
+use CommonsBooking\View\Stats;
+use CommonsBooking\Wordpress\Shortcode\BookingStats as BookingStatsShortcode;
 use CommonsBooking\Wordpress\CustomPostType\CustomPostType;
 use CommonsBooking\Wordpress\CustomPostType\Item;
 use CommonsBooking\Wordpress\CustomPostType\Location;
@@ -56,6 +60,9 @@ class Plugin {
 
 		// Init booking codes table
 		BookingCodes::initBookingCodesTable();
+
+		// Init booking stats table
+		BookingStatsRepo::initTable();
 
 		self::clearCache();
 	}
@@ -323,6 +330,9 @@ class Plugin {
 	}
 
 	public static function admin_init() {
+		// Ensure stats table exists on existing installs (dbDelta is idempotent).
+		BookingStatsRepo::initTable();
+
 		// check if we have a new version and run tasks
 		Upgrade::runTasksAfterUpdate();
 
@@ -408,6 +418,16 @@ class Plugin {
 				array( MassOperations::class, 'index' )
 			);
 		}
+
+		// Statistics – visible to all CB managers
+		add_submenu_page(
+			'cb-dashboard',
+			esc_html__( 'Statistics', 'commonsbooking' ),
+			esc_html__( 'Statistics', 'commonsbooking' ),
+			'manage_' . COMMONSBOOKING_PLUGIN_SLUG,
+			'cb-stats',
+			array( Stats::class, 'index' )
+		);
 	}
 
 	/**
@@ -706,6 +726,7 @@ class Plugin {
 
 	public function registerShortcodes() {
 		add_shortcode( 'cb_search', array( SearchShortcode::class, 'execute' ) );
+		add_shortcode( 'cb_booking_stats', array( BookingStatsShortcode::class, 'render' ) );
 	}
 
 	/**
@@ -783,6 +804,12 @@ class Plugin {
 
 		// register shortcodes
 		add_action( 'init', array( $this, 'registerShortcodes' ) );
+
+		// Keep booking stats table in sync when booking status changes.
+		add_action( 'transition_post_status', array( BookingStatsService::class, 'handleStatusTransition' ), 10, 3 );
+
+		// Handle "Recompute Statistics" admin POST.
+		add_action( 'admin_post_cb_recompute_stats', array( Stats::class, 'handleRecompute' ) );
 
 		// Remove cache items on save.
 		add_action( 'wp_insert_post', array( $this, 'savePostActions' ), 10, 3 );

--- a/src/Repository/BookingStats.php
+++ b/src/Repository/BookingStats.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace CommonsBooking\Repository;
+
+use CommonsBooking\Model\Booking;
+
+/**
+ * Manages the cb_booking_stats table, which stores pre-aggregated booking
+ * counts and durations per day per entity (global / item / location).
+ *
+ * Schema:
+ *   stat_date    date         – the booking's start date
+ *   entity_type  varchar(20)  – 'all', 'item', or 'location'
+ *   entity_id    bigint       – 0 for 'all', otherwise the WP post ID
+ *   booking_count int         – confirmed bookings starting on stat_date
+ *   booking_days  int         – sum of getDuration() for those bookings
+ */
+class BookingStats {
+
+	public static string $tablename = 'cb_booking_stats';
+
+	// -------------------------------------------------------------------------
+	// Table lifecycle
+	// -------------------------------------------------------------------------
+
+	public static function initTable(): void {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . self::$tablename;
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE $table_name (
+            stat_date    date         NOT NULL,
+            entity_type  varchar(20)  NOT NULL,
+            entity_id    bigint(20) UNSIGNED NOT NULL DEFAULT 0,
+            booking_count int(11)    NOT NULL DEFAULT 0,
+            booking_days  int(11)    NOT NULL DEFAULT 0,
+            PRIMARY KEY (stat_date, entity_type, entity_id),
+            KEY entity_lookup (entity_type, entity_id, stat_date)
+        ) $charset_collate;";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	// -------------------------------------------------------------------------
+	// Write operations
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Increment stats for a newly confirmed booking.
+	 * Safe to call multiple times – uses INSERT … ON DUPLICATE KEY UPDATE.
+	 */
+	public static function recordBooking( Booking $booking ): void {
+		$date     = self::bookingDateString( $booking );
+		$duration = max( 0, (int) $booking->getDuration() );
+		$itemId   = (int) $booking->getItemID();
+		$locId    = (int) $booking->getLocationID();
+
+		if ( ! $date ) {
+			return;
+		}
+
+		self::upsertRow( $date, 'all', 0, 1, $duration );
+		if ( $itemId ) {
+			self::upsertRow( $date, 'item', $itemId, 1, $duration );
+		}
+		if ( $locId ) {
+			self::upsertRow( $date, 'location', $locId, 1, $duration );
+		}
+	}
+
+	/**
+	 * Decrement stats when a booking is cancelled or deleted.
+	 */
+	public static function removeBooking( Booking $booking ): void {
+		$date     = self::bookingDateString( $booking );
+		$duration = max( 0, (int) $booking->getDuration() );
+		$itemId   = (int) $booking->getItemID();
+		$locId    = (int) $booking->getLocationID();
+
+		if ( ! $date ) {
+			return;
+		}
+
+		self::decrementRow( $date, 'all', 0, 1, $duration );
+		if ( $itemId ) {
+			self::decrementRow( $date, 'item', $itemId, 1, $duration );
+		}
+		if ( $locId ) {
+			self::decrementRow( $date, 'location', $locId, 1, $duration );
+		}
+	}
+
+	/**
+	 * Rebuild the entire stats table from scratch.
+	 * Should be run as a background task or triggered manually by an admin.
+	 */
+	public static function recomputeAll(): void {
+		global $wpdb;
+
+		$wpdb->query( 'TRUNCATE TABLE ' . $wpdb->prefix . self::$tablename ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+
+		$bookings = \CommonsBooking\Repository\Booking::get( [], [], null, true, null, [ 'confirmed' ] );
+		foreach ( $bookings as $booking ) {
+			self::recordBooking( $booking );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Read operations
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Return aggregated booking_count and booking_days for a date range and entity.
+	 *
+	 * @param \DateTimeImmutable $from        Inclusive start date.
+	 * @param \DateTimeImmutable $to          Inclusive end date.
+	 * @param string             $entityType  'all', 'item', or 'location'.
+	 * @param int                $entityId    0 for global; post ID for item/location.
+	 *
+	 * @return array{count: int, days: int}
+	 */
+	public static function getAggregated(
+		\DateTimeImmutable $from,
+		\DateTimeImmutable $to,
+		string $entityType = 'all',
+		int $entityId = 0
+	): array {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::$tablename;
+
+		$row = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare(
+				"SELECT COALESCE(SUM(booking_count),0) AS cnt, COALESCE(SUM(booking_days),0) AS days
+				 FROM $table
+				 WHERE stat_date BETWEEN %s AND %s
+				   AND entity_type = %s
+				   AND entity_id   = %d",
+				$from->format( 'Y-m-d' ),
+				$to->format( 'Y-m-d' ),
+				$entityType,
+				$entityId
+			),
+			ARRAY_A
+		);
+
+		return [
+			'count' => isset( $row['cnt'] ) ? (int) $row['cnt'] : 0,
+			'days'  => isset( $row['days'] ) ? (int) $row['days'] : 0,
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers
+	// -------------------------------------------------------------------------
+
+	private static function upsertRow( string $date, string $entityType, int $entityId, int $count, int $days ): void {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::$tablename;
+
+		$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare(
+				"INSERT INTO $table (stat_date, entity_type, entity_id, booking_count, booking_days)
+				 VALUES (%s, %s, %d, %d, %d)
+				 ON DUPLICATE KEY UPDATE
+				     booking_count = booking_count + VALUES(booking_count),
+				     booking_days  = booking_days  + VALUES(booking_days)",
+				$date,
+				$entityType,
+				$entityId,
+				$count,
+				$days
+			)
+		);
+	}
+
+	private static function decrementRow( string $date, string $entityType, int $entityId, int $count, int $days ): void {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::$tablename;
+
+		$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare(
+				"UPDATE $table
+				 SET booking_count = GREATEST(0, booking_count - %d),
+				     booking_days  = GREATEST(0, booking_days  - %d)
+				 WHERE stat_date   = %s
+				   AND entity_type = %s
+				   AND entity_id   = %d",
+				$count,
+				$days,
+				$date,
+				$entityType,
+				$entityId
+			)
+		);
+	}
+
+	private static function bookingDateString( Booking $booking ): ?string {
+		try {
+			$ts = $booking->getStartDate();
+			if ( ! $ts ) {
+				return null;
+			}
+			return date( 'Y-m-d', $ts );
+		} catch ( \Exception $e ) {
+			return null;
+		}
+	}
+}

--- a/src/Service/BookingStats.php
+++ b/src/Service/BookingStats.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace CommonsBooking\Service;
+
+use CommonsBooking\Model\Booking;
+use CommonsBooking\Repository\BookingStats as BookingStatsRepo;
+use CommonsBooking\Wordpress\CustomPostType\Booking as BookingCPT;
+
+/**
+ * High-level booking statistics service.
+ *
+ * Resolves "entity type / entity id" from optional item/location IDs,
+ * computes period date ranges, and delegates reads to BookingStatsRepo.
+ * Also handles the transition_post_status hook to keep the stats table in sync.
+ */
+class BookingStats {
+
+	// -------------------------------------------------------------------------
+	// Lifecycle hook (called from Plugin::init via transition_post_status)
+	// -------------------------------------------------------------------------
+
+	public static function handleStatusTransition( string $newStatus, string $oldStatus, \WP_Post $post ): void {
+		if ( $post->post_type !== BookingCPT::$postType ) {
+			return;
+		}
+		if ( $newStatus === $oldStatus ) {
+			return;
+		}
+
+		try {
+			$booking = new Booking( $post->ID );
+		} catch ( \Exception $e ) {
+			return;
+		}
+
+		if ( $newStatus === 'confirmed' ) {
+			BookingStatsRepo::recordBooking( $booking );
+		} elseif ( $oldStatus === 'confirmed' ) {
+			BookingStatsRepo::removeBooking( $booking );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Period stats API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @return array{current: array{count: int, days: int}, previous: array{count: int, days: int}, diff_count: int, diff_pct: float|null}
+	 */
+	public static function getDayStats( ?int $itemId = null, ?int $locationId = null ): array {
+		[ $entityType, $entityId ] = self::resolveEntity( $itemId, $locationId );
+
+		[ $curFrom, $curTo ]  = self::currentDay();
+		[ $prevFrom, $prevTo ] = self::previousDay();
+
+		return self::buildResult( $curFrom, $curTo, $prevFrom, $prevTo, $entityType, $entityId );
+	}
+
+	/**
+	 * @return array{current: array{count: int, days: int}, previous: array{count: int, days: int}, diff_count: int, diff_pct: float|null}
+	 */
+	public static function getWeekStats( ?int $itemId = null, ?int $locationId = null ): array {
+		[ $entityType, $entityId ] = self::resolveEntity( $itemId, $locationId );
+
+		[ $curFrom, $curTo ]  = self::currentWeek();
+		[ $prevFrom, $prevTo ] = self::previousWeek();
+
+		return self::buildResult( $curFrom, $curTo, $prevFrom, $prevTo, $entityType, $entityId );
+	}
+
+	/**
+	 * @return array{current: array{count: int, days: int}, previous: array{count: int, days: int}, diff_count: int, diff_pct: float|null}
+	 */
+	public static function getMonthStats( ?int $itemId = null, ?int $locationId = null ): array {
+		[ $entityType, $entityId ] = self::resolveEntity( $itemId, $locationId );
+
+		[ $curFrom, $curTo ]  = self::currentMonth();
+		[ $prevFrom, $prevTo ] = self::previousMonth();
+
+		return self::buildResult( $curFrom, $curTo, $prevFrom, $prevTo, $entityType, $entityId );
+	}
+
+	/**
+	 * @return array{current: array{count: int, days: int}, previous: array{count: int, days: int}, diff_count: int, diff_pct: float|null}
+	 */
+	public static function getYearStats( ?int $itemId = null, ?int $locationId = null ): array {
+		[ $entityType, $entityId ] = self::resolveEntity( $itemId, $locationId );
+
+		[ $curFrom, $curTo ]  = self::currentYear();
+		[ $prevFrom, $prevTo ] = self::previousYear();
+
+		return self::buildResult( $curFrom, $curTo, $prevFrom, $prevTo, $entityType, $entityId );
+	}
+
+	/**
+	 * Generic period stats lookup – used by the shortcode.
+	 *
+	 * @param string   $period      'day'|'week'|'month'|'year'
+	 * @param int|null $itemId
+	 * @param int|null $locationId
+	 *
+	 * @return array{current: array{count: int, days: int}, previous: array{count: int, days: int}, diff_count: int, diff_pct: float|null}
+	 */
+	public static function getPeriodStats( string $period, ?int $itemId = null, ?int $locationId = null ): array {
+		switch ( $period ) {
+			case 'day':
+				return self::getDayStats( $itemId, $locationId );
+			case 'month':
+				return self::getMonthStats( $itemId, $locationId );
+			case 'year':
+				return self::getYearStats( $itemId, $locationId );
+			default:
+				return self::getWeekStats( $itemId, $locationId );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers – entity resolution
+	// -------------------------------------------------------------------------
+
+	/** @return array{string, int} */
+	private static function resolveEntity( ?int $itemId, ?int $locationId ): array {
+		if ( $itemId ) {
+			return [ 'item', $itemId ];
+		}
+		if ( $locationId ) {
+			return [ 'location', $locationId ];
+		}
+		return [ 'all', 0 ];
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers – period date ranges
+	// -------------------------------------------------------------------------
+
+	/** @return array{\DateTimeImmutable, \DateTimeImmutable} */
+	private static function currentDay(): array {
+		$today = new \DateTimeImmutable( 'today' );
+		return [ $today, $today ];
+	}
+
+	/** @return array{\DateTimeImmutable, \DateTimeImmutable} */
+	private static function previousDay(): array {
+		$yesterday = new \DateTimeImmutable( 'yesterday' );
+		return [ $yesterday, $yesterday ];
+	}
+
+	/** @return array{\DateTimeImmutable, \DateTimeImmutable} */
+	private static function currentWeek(): array {
+		$from = new \DateTimeImmutable( 'monday this week' );
+		$to   = new \DateTimeImmutable( 'sunday this week' );
+		return [ $from, $to ];
+	}
+
+	/** @return array{\DateTimeImmutable, \DateTimeImmutable} */
+	private static function previousWeek(): array {
+		$from = new \DateTimeImmutable( 'monday last week' );
+		$to   = new \DateTimeImmutable( 'sunday last week' );
+		return [ $from, $to ];
+	}
+
+	/** @return array{\DateTimeImmutable, \DateTimeImmutable} */
+	private static function currentMonth(): array {
+		$from = new \DateTimeImmutable( 'first day of this month' );
+		$to   = new \DateTimeImmutable( 'last day of this month' );
+		return [ $from, $to ];
+	}
+
+	/** @return array{\DateTimeImmutable, \DateTimeImmutable} */
+	private static function previousMonth(): array {
+		$from = new \DateTimeImmutable( 'first day of last month' );
+		$to   = new \DateTimeImmutable( 'last day of last month' );
+		return [ $from, $to ];
+	}
+
+	/** @return array{\DateTimeImmutable, \DateTimeImmutable} */
+	private static function currentYear(): array {
+		$year = (int) date( 'Y' );
+		$from = new \DateTimeImmutable( "$year-01-01" );
+		$to   = new \DateTimeImmutable( "$year-12-31" );
+		return [ $from, $to ];
+	}
+
+	/** @return array{\DateTimeImmutable, \DateTimeImmutable} */
+	private static function previousYear(): array {
+		$year = (int) date( 'Y' ) - 1;
+		$from = new \DateTimeImmutable( "$year-01-01" );
+		$to   = new \DateTimeImmutable( "$year-12-31" );
+		return [ $from, $to ];
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers – result building
+	// -------------------------------------------------------------------------
+
+	/** @return array{current: array{count: int, days: int}, previous: array{count: int, days: int}, diff_count: int, diff_pct: float|null} */
+	private static function buildResult(
+		\DateTimeImmutable $curFrom,
+		\DateTimeImmutable $curTo,
+		\DateTimeImmutable $prevFrom,
+		\DateTimeImmutable $prevTo,
+		string $entityType,
+		int $entityId
+	): array {
+		$current  = BookingStatsRepo::getAggregated( $curFrom, $curTo, $entityType, $entityId );
+		$previous = BookingStatsRepo::getAggregated( $prevFrom, $prevTo, $entityType, $entityId );
+
+		$diffCount = $current['count'] - $previous['count'];
+		$diffPct   = $previous['count'] > 0
+			? round( ( $diffCount / $previous['count'] ) * 100, 1 )
+			: null;
+
+		return [
+			'current'    => $current,
+			'previous'   => $previous,
+			'diff_count' => $diffCount,
+			'diff_pct'   => $diffPct,
+		];
+	}
+}

--- a/src/View/Stats.php
+++ b/src/View/Stats.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace CommonsBooking\View;
+
+use CommonsBooking\Repository\BookingStats as BookingStatsRepo;
+use CommonsBooking\Service\BookingStats as BookingStatsService;
+
+/**
+ * Admin view for booking statistics.
+ * Renders the stats page at CommonsBooking → Statistics.
+ */
+class Stats extends View {
+
+	public static function index(): void {
+		ob_start();
+		commonsbooking_sanitizeHTML( commonsbooking_get_template_part( 'stats', 'index' ) );
+		echo ob_get_clean();
+	}
+
+	/**
+	 * Handle the "Recompute Statistics" admin POST action.
+	 */
+	public static function handleRecompute(): void {
+		if ( ! current_user_can( 'manage_' . COMMONSBOOKING_PLUGIN_SLUG ) ) {
+			wp_die( esc_html__( 'Insufficient permissions.', 'commonsbooking' ) );
+		}
+		check_admin_referer( 'cb_recompute_stats' );
+
+		BookingStatsRepo::recomputeAll();
+
+		wp_safe_redirect(
+			add_query_arg(
+				[ 'page' => 'cb-stats', 'recomputed' => '1' ],
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Build all four stat card data sets, optionally filtered by item or location.
+	 *
+	 * Called from the template.
+	 *
+	 * @return array{day: array, week: array, month: array, year: array}
+	 */
+	public static function getStatCards( ?int $itemId, ?int $locationId ): array {
+		return [
+			'day'   => BookingStatsService::getDayStats( $itemId, $locationId ),
+			'week'  => BookingStatsService::getWeekStats( $itemId, $locationId ),
+			'month' => BookingStatsService::getMonthStats( $itemId, $locationId ),
+			'year'  => BookingStatsService::getYearStats( $itemId, $locationId ),
+		];
+	}
+
+	/**
+	 * Render one period stat card as an HTML string.
+	 *
+	 * @param string $label  Human-readable period label (e.g. "This Week").
+	 * @param string $compareLabel  Label for the comparison period (e.g. "last week").
+	 * @param array  $stats  Result from BookingStatsService::get*Stats().
+	 *
+	 * @return string
+	 */
+	public static function renderPeriodCard( string $label, string $compareLabel, array $stats ): string {
+		$current    = $stats['current']['count'];
+		$diffCount  = $stats['diff_count'];
+		$diffPct    = $stats['diff_pct'];
+		$days       = $stats['current']['days'];
+
+		$diffHtml = self::formatDiff( $diffCount, $diffPct, $compareLabel );
+
+		$html  = '<div class="cb-stat-card" style="background:#fff;border:1px solid #ddd;border-radius:4px;padding:16px 20px;min-width:160px;">';
+		$html .= '<div class="cb-stat-label" style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:.05em;">' . esc_html( $label ) . '</div>';
+		$html .= '<div class="cb-stat-value" style="font-size:32px;font-weight:700;margin:4px 0;">' . esc_html( (string) $current ) . '</div>';
+		$html .= '<div class="cb-stat-sub" style="font-size:12px;color:#888;">' . esc_html__( 'bookings', 'commonsbooking' );
+		if ( $days > 0 ) {
+			$html .= ' &nbsp;·&nbsp; ' . esc_html( (string) $days ) . ' ' . esc_html__( 'days', 'commonsbooking' );
+		}
+		$html .= '</div>';
+		$html .= '<div class="cb-stat-diff" style="margin-top:8px;font-size:13px;">' . $diffHtml . '</div>';
+		$html .= '</div>';
+
+		return $html;
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers
+	// -------------------------------------------------------------------------
+
+	private static function formatDiff( int $diffCount, ?float $diffPct, string $compareLabel ): string {
+		if ( $diffCount === 0 ) {
+			$arrow = '=';
+			$color = '#888';
+		} elseif ( $diffCount > 0 ) {
+			$arrow = '&#9650;';
+			$color = '#67b32a';
+		} else {
+			$arrow = '&#9660;';
+			$color = '#c0392b';
+		}
+
+		$pctText = $diffPct !== null ? ' (' . abs( $diffPct ) . '%)' : '';
+
+		return sprintf(
+			'<span style="color:%s">%s %s%s</span> <span style="color:#999">%s %s</span>',
+			$color,
+			$arrow,
+			abs( $diffCount ),
+			esc_html( $pctText ),
+			esc_html__( 'vs', 'commonsbooking' ),
+			esc_html( $compareLabel )
+		);
+	}
+}

--- a/src/Wordpress/Shortcode/BookingStats.php
+++ b/src/Wordpress/Shortcode/BookingStats.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace CommonsBooking\Wordpress\Shortcode;
+
+use CommonsBooking\Service\BookingStats as BookingStatsService;
+
+/**
+ * Shortcode [cb_booking_stats] — displays a booking statistics snippet.
+ *
+ * Attributes:
+ *   period   = day | week | month | year   (default: week)
+ *   compare  = true | false                (default: true)
+ *   item     = <WP post ID> | all          (default: all)
+ *   location = <WP post ID> | all          (default: all)
+ *   show     = count | days | both         (default: count)
+ *
+ * Examples:
+ *   [cb_booking_stats]
+ *   [cb_booking_stats period="week" compare="true"]
+ *   [cb_booking_stats period="month" compare="true"]
+ *   [cb_booking_stats period="year" compare="true"]
+ *   [cb_booking_stats period="week" item="42"]
+ *   [cb_booking_stats period="month" location="17"]
+ *   [cb_booking_stats period="week" show="both"]
+ *   [cb_booking_stats period="year" compare="false"]
+ */
+class BookingStats {
+
+	/**
+	 * Shortcode render callback.
+	 *
+	 * @param array|string $atts Shortcode attributes.
+	 *
+	 * @return string HTML output.
+	 */
+	public static function render( $atts ): string {
+		$atts = shortcode_atts(
+			[
+				'period'   => 'week',
+				'compare'  => 'true',
+				'item'     => 'all',
+				'location' => 'all',
+				'show'     => 'count',
+			],
+			$atts,
+			'cb_booking_stats'
+		);
+
+		$period    = in_array( $atts['period'], [ 'day', 'week', 'month', 'year' ], true ) ? $atts['period'] : 'week';
+		$compare   = filter_var( $atts['compare'], FILTER_VALIDATE_BOOLEAN );
+		$itemId    = ( $atts['item'] !== 'all' && is_numeric( $atts['item'] ) ) ? (int) $atts['item'] : null;
+		$locationId = ( $atts['location'] !== 'all' && is_numeric( $atts['location'] ) ) ? (int) $atts['location'] : null;
+		$show      = in_array( $atts['show'], [ 'count', 'days', 'both' ], true ) ? $atts['show'] : 'count';
+
+		$stats = BookingStatsService::getPeriodStats( $period, $itemId, $locationId );
+
+		return self::buildHtml( $period, $compare, $show, $stats, $itemId, $locationId );
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers
+	// -------------------------------------------------------------------------
+
+	private static function buildHtml(
+		string $period,
+		bool $compare,
+		string $show,
+		array $stats,
+		?int $itemId,
+		?int $locationId
+	): string {
+		$count    = $stats['current']['count'];
+		$days     = $stats['current']['days'];
+		$diff     = $stats['diff_count'];
+		$diffPct  = $stats['diff_pct'];
+
+		$periodLabel   = self::periodLabel( $period );
+		$compareLabel  = self::comparePeriodLabel( $period );
+
+		// Build the entity context label (e.g. "for Cargo Bike Berlin").
+		$contextLabel = self::entityLabel( $itemId, $locationId );
+
+		// Main value string.
+		$valueStr = self::valueString( $count, $days, $show );
+
+		// Build the intro phrase.
+		$intro = sprintf(
+			/* translators: 1: period label, 2: entity context (may be empty) */
+			_x( 'Bookings %1$s%2$s', 'stat shortcode intro', 'commonsbooking' ),
+			$periodLabel,
+			$contextLabel ? ( ' ' . $contextLabel ) : ''
+		);
+
+		$html = '<span class="cb-booking-stats">'
+			. '<strong>' . esc_html( $intro ) . ':</strong> '
+			. '<span class="cb-stat-value">' . esc_html( $valueStr ) . '</span>';
+
+		if ( $compare ) {
+			$html .= ' ' . self::diffBadge( $diff, $diffPct, $compareLabel );
+		}
+
+		$html .= '</span>';
+
+		return $html;
+	}
+
+	private static function valueString( int $count, int $days, string $show ): string {
+		if ( $show === 'days' ) {
+			/* translators: number of booking days */
+			return sprintf( _n( '%d day', '%d days', $days, 'commonsbooking' ), $days );
+		}
+		if ( $show === 'both' ) {
+			return sprintf(
+				/* translators: 1: booking count, 2: days */
+				_x( '%1$d bookings / %2$d days', 'stat shortcode value', 'commonsbooking' ),
+				$count,
+				$days
+			);
+		}
+		// default: count
+		return (string) $count;
+	}
+
+	private static function diffBadge( int $diff, ?float $diffPct, string $compareLabel ): string {
+		if ( $diff === 0 ) {
+			$symbol = '=';
+			$color  = '#888';
+		} elseif ( $diff > 0 ) {
+			$symbol = '&#9650;';
+			$color  = '#67b32a';
+		} else {
+			$symbol = '&#9660;';
+			$color  = '#c0392b';
+		}
+
+		$pctText = $diffPct !== null ? ' (' . abs( $diffPct ) . '%)' : '';
+
+		return sprintf(
+			'<span class="cb-stat-diff" style="color:%s;">(%s&nbsp;%s%s %s %s)</span>',
+			esc_attr( $color ),
+			$symbol,
+			esc_html( (string) abs( $diff ) ),
+			esc_html( $pctText ),
+			esc_html__( 'vs', 'commonsbooking' ),
+			esc_html( $compareLabel )
+		);
+	}
+
+	private static function periodLabel( string $period ): string {
+		$labels = [
+			'day'   => __( 'today', 'commonsbooking' ),
+			'week'  => __( 'this week', 'commonsbooking' ),
+			'month' => __( 'this month', 'commonsbooking' ),
+			'year'  => __( 'this year', 'commonsbooking' ),
+		];
+		return $labels[ $period ] ?? $period;
+	}
+
+	private static function comparePeriodLabel( string $period ): string {
+		$labels = [
+			'day'   => __( 'yesterday', 'commonsbooking' ),
+			'week'  => __( 'last week', 'commonsbooking' ),
+			'month' => __( 'last month', 'commonsbooking' ),
+			'year'  => __( 'last year', 'commonsbooking' ),
+		];
+		return $labels[ $period ] ?? $period;
+	}
+
+	private static function entityLabel( ?int $itemId, ?int $locationId ): string {
+		if ( $itemId ) {
+			$post = get_post( $itemId );
+			if ( $post ) {
+				/* translators: item name */
+				return sprintf( __( 'for %s', 'commonsbooking' ), $post->post_title );
+			}
+		}
+		if ( $locationId ) {
+			$post = get_post( $locationId );
+			if ( $post ) {
+				/* translators: location name */
+				return sprintf( __( 'at %s', 'commonsbooking' ), $post->post_title );
+			}
+		}
+		return '';
+	}
+}

--- a/templates/stats-index.php
+++ b/templates/stats-index.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Template: Booking Statistics admin page.
+ * Called via CommonsBooking\View\Stats::index().
+ */
+
+use CommonsBooking\Repository\Item as ItemRepo;
+use CommonsBooking\Repository\Location as LocationRepo;
+use CommonsBooking\View\Stats;
+
+// Read filter params from GET (sanitized).
+$selectedItem     = isset( $_GET['cb_stats_item'] ) ? (int) $_GET['cb_stats_item'] : 0;
+$selectedLocation = isset( $_GET['cb_stats_location'] ) ? (int) $_GET['cb_stats_location'] : 0;
+
+// When an item is selected we ignore the location filter and vice-versa.
+$filterItemId     = $selectedItem ?: null;
+$filterLocationId = $selectedItem ? null : ( $selectedLocation ?: null );
+
+// Compute stat cards.
+$cards = Stats::getStatCards( $filterItemId, $filterLocationId );
+
+// Fetch items and locations for the filter dropdowns.
+$items     = ItemRepo::get();
+$locations = LocationRepo::get();
+?>
+<h1><?php echo esc_html__( 'Booking Statistics', 'commonsbooking' ); ?></h1>
+
+<div class="wrap">
+
+	<?php if ( isset( $_GET['recomputed'] ) && $_GET['recomputed'] === '1' ) : ?>
+		<div class="notice notice-success is-dismissible">
+			<p><?php echo esc_html__( 'Statistics have been recomputed successfully.', 'commonsbooking' ); ?></p>
+		</div>
+	<?php endif; ?>
+
+	<!-- Filter form -->
+	<div class="cb_welcome-panel" style="margin-bottom:20px;">
+		<div class="cb_welcome-panel-content">
+			<h3><?php echo esc_html__( 'Filter', 'commonsbooking' ); ?></h3>
+			<form method="get" action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>">
+				<input type="hidden" name="page" value="cb-stats">
+				<div style="display:flex;gap:16px;align-items:flex-end;flex-wrap:wrap;">
+					<div>
+						<label for="cb_stats_item" style="display:block;font-weight:600;margin-bottom:4px;">
+							<?php echo esc_html__( 'Item', 'commonsbooking' ); ?>
+						</label>
+						<select name="cb_stats_item" id="cb_stats_item" style="min-width:180px;">
+							<option value="0"><?php echo esc_html__( '— All items —', 'commonsbooking' ); ?></option>
+							<?php foreach ( $items as $item ) : ?>
+								<option value="<?php echo esc_attr( $item->ID ); ?>" <?php selected( $selectedItem, $item->ID ); ?>>
+									<?php echo esc_html( $item->post_title ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+					</div>
+					<div>
+						<label for="cb_stats_location" style="display:block;font-weight:600;margin-bottom:4px;">
+							<?php echo esc_html__( 'Location', 'commonsbooking' ); ?>
+						</label>
+						<select name="cb_stats_location" id="cb_stats_location" style="min-width:180px;">
+							<option value="0"><?php echo esc_html__( '— All locations —', 'commonsbooking' ); ?></option>
+							<?php foreach ( $locations as $location ) : ?>
+								<option value="<?php echo esc_attr( $location->ID ); ?>" <?php selected( $selectedLocation, $location->ID ); ?>>
+									<?php echo esc_html( $location->post_title ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+					</div>
+					<div>
+						<button type="submit" class="button button-primary">
+							<?php echo esc_html__( 'Apply', 'commonsbooking' ); ?>
+						</button>
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=cb-stats' ) ); ?>" class="button" style="margin-left:6px;">
+							<?php echo esc_html__( 'Reset', 'commonsbooking' ); ?>
+						</a>
+					</div>
+				</div>
+			</form>
+		</div>
+	</div>
+
+	<hr style="border-top:8px solid #67b32a;border-radius:5px;margin:0 0 20px;">
+
+	<!-- Stat cards -->
+	<div style="display:flex;gap:16px;flex-wrap:wrap;margin-bottom:24px;">
+		<?php
+		$periodConfig = [
+			'day'   => [
+				'label'        => __( 'Today', 'commonsbooking' ),
+				'compareLabel' => __( 'yesterday', 'commonsbooking' ),
+			],
+			'week'  => [
+				'label'        => __( 'This Week', 'commonsbooking' ),
+				'compareLabel' => __( 'last week', 'commonsbooking' ),
+			],
+			'month' => [
+				'label'        => __( 'This Month', 'commonsbooking' ),
+				'compareLabel' => __( 'last month', 'commonsbooking' ),
+			],
+			'year'  => [
+				'label'        => __( 'This Year', 'commonsbooking' ),
+				'compareLabel' => __( 'last year', 'commonsbooking' ),
+			],
+		];
+
+		foreach ( $periodConfig as $key => $cfg ) {
+			echo commonsbooking_sanitizeHTML(
+				Stats::renderPeriodCard( $cfg['label'], $cfg['compareLabel'], $cards[ $key ] )
+			);
+		}
+		?>
+	</div>
+
+	<!-- Recompute action -->
+	<?php if ( commonsbooking_isCurrentUserAdmin() ) : ?>
+		<div class="cb_welcome-panel" style="margin-top:24px;">
+			<div class="cb_welcome-panel-content">
+				<h3><?php echo esc_html__( 'Maintenance', 'commonsbooking' ); ?></h3>
+				<p style="color:#666;">
+					<?php echo esc_html__( 'If statistics look incorrect, you can recompute them from all existing confirmed bookings. This may take a moment on large datasets.', 'commonsbooking' ); ?>
+				</p>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="cb_recompute_stats">
+					<?php wp_nonce_field( 'cb_recompute_stats' ); ?>
+					<button type="submit" class="button button-secondary">
+						<?php echo esc_html__( 'Recompute Statistics', 'commonsbooking' ); ?>
+					</button>
+				</form>
+			</div>
+		</div>
+	<?php endif; ?>
+
+</div>


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive booking statistics system for Commons Booking, including a pre-aggregated stats table, service layer for querying statistics, an admin dashboard page, and a shortcode for displaying stats on the frontend.

## Key Changes

### New Database Table & Repository
- **`BookingStats` Repository** (`src/Repository/BookingStats.php`): Manages the `cb_booking_stats` table with pre-aggregated booking counts and durations per day per entity (global/item/location)
  - Implements `recordBooking()` and `removeBooking()` to keep stats in sync when bookings are confirmed/cancelled
  - Provides `getAggregated()` for efficient range queries
  - Includes `recomputeAll()` for rebuilding stats from scratch
  - Uses `INSERT ... ON DUPLICATE KEY UPDATE` for safe concurrent updates

### Service Layer
- **`BookingStats` Service** (`src/Service/BookingStats.php`): High-level API for statistics queries
  - Provides period-specific methods: `getDayStats()`, `getWeekStats()`, `getMonthStats()`, `getYearStats()`
  - Generic `getPeriodStats()` method for flexible period selection
  - Handles entity resolution (item/location/global) and date range computation
  - Hooks into `transition_post_status` to automatically sync stats when booking status changes
  - Returns structured data with current/previous period comparisons and percentage deltas

### Admin Dashboard
- **`Stats` View** (`src/View/Stats.php`): Admin page controller
  - Renders statistics dashboard at CommonsBooking → Statistics
  - Supports filtering by item or location
  - Handles "Recompute Statistics" admin action with nonce verification
  - Generates stat cards for day/week/month/year periods

- **Stats Template** (`templates/stats-index.php`): Admin UI
  - Filter form for selecting items/locations
  - Four stat cards showing current period vs. comparison period with visual indicators
  - Maintenance section with recompute button (admin-only)
  - Success notice after recomputation

### Frontend Shortcode
- **`BookingStats` Shortcode** (`src/Wordpress/Shortcode/BookingStats.php`): `[cb_booking_stats]`
  - Attributes: `period` (day/week/month/year), `compare` (true/false), `item`/`location` (ID or "all"), `show` (count/days/both)
  - Displays booking statistics with optional comparison to previous period
  - Color-coded diff indicators (green for increase, red for decrease)
  - Fully translatable output with proper escaping

### Plugin Integration
- **`Plugin.php`**: 
  - Initializes stats table on plugin activation
  - Ensures table exists on admin_init (for existing installations)
  - Registers admin menu page for statistics dashboard
  - Registers booking stats shortcode
  - Hooks `BookingStatsService::handleStatusTransition()` to `transition_post_status`

## Implementation Details

- **Efficient Aggregation**: Pre-aggregated daily stats eliminate need for expensive queries over large booking datasets
- **Automatic Sync**: Stats table stays in sync via WordPress post status transitions—no manual triggers needed
- **Safe Concurrent Updates**: Uses MySQL `ON DUPLICATE KEY UPDATE` to handle race conditions
- **Flexible Filtering**: Supports global, per-item, and per-location statistics
- **Comparison Metrics**: Automatically calculates period-over-period deltas with percentage changes
- **Idempotent Table Creation**: Uses `dbDelta()` for safe schema initialization on existing installs
- **Translatable**: All UI strings use WordPress i18n functions with proper context

https://claude.ai/code/session_01893WfsffpRupUqYoStyKaG