### PR TITLE
Skip Strauss on composer install when vendor-prefixed already exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,10 +72,13 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "@prefix-namespaces"
+      "@prefix-namespaces-if-missing"
     ],
     "post-update-cmd": [
       "@prefix-namespaces"
+    ],
+    "prefix-namespaces-if-missing": [
+      "sh -c 'test -d ./vendor-prefixed || composer run prefix-namespaces'"
     ],
     "prefix-namespaces": [
       "sh -c 'test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.26.5/strauss.phar'",


### PR DESCRIPTION
Running Strauss on every `composer install` wastes ~2 minutes when
dependencies haven't changed. The new `prefix-namespaces-if-missing`
script only runs the full Strauss pass if `vendor-prefixed/` is absent,
while `post-update-cmd` still always re-scopes after dependency changes.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y1xu2m3ALWV3u7sg7vHUeN