### PR TITLE
Add Jetpack, SEO plugin, Gutenberg, and Polylang integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ assets/packaged
 .idea
 
 .phpunit.result.cache
+.cache-phpcs-free.cache
 tests/cypress/screenshots
 docs/.vitepress/dist
 /vendor-prefixed

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -203,6 +203,17 @@ abstract class Message {
 		// WPML: Switch system language to user´s set lang https://wpml.org/documentation/support/sending-emails-with-wpml/
 		do_action( 'wpml_switch_language_for_email', $recipientUser->getEmail() );
 
+		// Polylang: Switch language to the user's preferred language before building the email body.
+		if ( function_exists( 'pll_get_user_language' ) && function_exists( 'PLL' ) ) {
+			$wp_user = get_user_by( 'email', $recipientUser->getEmail() );
+			if ( $wp_user ) {
+				$user_lang = pll_get_user_language( $wp_user->ID );
+				if ( $user_lang ) {
+					PLL()->curlang = PLL()->model->get_language( $user_lang );
+				}
+			}
+		}
+
 		// check if templates are available
 		if ( ! $template_body or ! $template_subject ) {
 			new WP_Error( 'e-mail ', commonsbooking_sanitizeHTML( __( 'Could not send email because mail-template was not available. Check options -> templates', 'commonsbooking' ) ) );
@@ -257,6 +268,12 @@ abstract class Message {
 		}
 		// WPML: Reset system lang
 		do_action( 'wpml_reset_language_after_mailing' );
+
+		// Polylang: Reset to default site language after sending.
+		if ( function_exists( 'pll_default_language' ) && function_exists( 'PLL' ) ) {
+			PLL()->curlang = PLL()->model->get_language( pll_default_language() );
+		}
+
 		do_action( 'commonsbooking_mail_sent', $this->getAction(), $result );
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,6 +25,9 @@ use CommonsBooking\Wordpress\CustomPostType\Location;
 use CommonsBooking\Wordpress\CustomPostType\Map;
 use CommonsBooking\Wordpress\CustomPostType\Restriction;
 use CommonsBooking\Wordpress\CustomPostType\Timeframe;
+use CommonsBooking\Wordpress\Compat\JetpackCompat;
+use CommonsBooking\Wordpress\Compat\SeoCompat;
+use CommonsBooking\Wordpress\Gutenberg\BlockPatterns;
 use CommonsBooking\Wordpress\Options\AdminOptions;
 use CommonsBooking\Wordpress\Options\OptionsTab;
 use CommonsBooking\Wordpress\PostStatus\PostStatus;
@@ -831,6 +834,13 @@ class Plugin {
 
 		// iCal rewrite
 		iCalendar::initRewrite();
+
+		// Third-party plugin compatibility
+		JetpackCompat::init();
+		SeoCompat::init();
+
+		// Gutenberg block patterns (wraps existing shortcodes — no JS needed)
+		BlockPatterns::init();
 	}
 
 	/**

--- a/src/Wordpress/Compat/JetpackCompat.php
+++ b/src/Wordpress/Compat/JetpackCompat.php
@@ -10,6 +10,9 @@ namespace CommonsBooking\Wordpress\Compat;
  */
 class JetpackCompat {
 
+	/**
+	 * Registers all Jetpack compatibility filters. No-op if Jetpack is not active.
+	 */
 	public static function init(): void {
 		if ( ! defined( 'JETPACK__VERSION' ) ) {
 			return;
@@ -33,7 +36,7 @@ class JetpackCompat {
 	 * Exclude cb_booking and cb_restriction from Jetpack Sync so that personal booking
 	 * data is not transmitted to WordPress.com infrastructure.
 	 *
-	 * @param string[] $post_types
+	 * @param string[] $post_types Post types currently blacklisted from Jetpack Sync.
 	 * @return string[]
 	 */
 	public static function excludePrivatePostTypesFromSync( array $post_types ): array {
@@ -47,8 +50,8 @@ class JetpackCompat {
 	 * Photon only handles media-library images; trying to proxy plugin asset URLs
 	 * results in broken references.
 	 *
-	 * @param bool   $skip
-	 * @param string $image_url
+	 * @param bool   $skip      Whether Photon is already set to skip this URL.
+	 * @param string $image_url The image URL being evaluated.
 	 * @return bool
 	 */
 	public static function skipPhotonForMapAssets( bool $skip, string $image_url ): bool {
@@ -66,7 +69,7 @@ class JetpackCompat {
 	 * Add CB map container classes to the Jetpack Lazy Images class blacklist so
 	 * that images inside Leaflet map wrappers are never lazy-loaded by Jetpack.
 	 *
-	 * @param string[] $blacklisted_classes
+	 * @param string[] $blacklisted_classes CSS classes already excluded from Jetpack lazy loading.
 	 * @return string[]
 	 */
 	public static function skipLazyImagesInMapContainers( array $blacklisted_classes ): array {

--- a/src/Wordpress/Compat/JetpackCompat.php
+++ b/src/Wordpress/Compat/JetpackCompat.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace CommonsBooking\Wordpress\Compat;
+
+/**
+ * Compatibility layer for Jetpack by Automattic.
+ *
+ * Hooks in this class only run when Jetpack is active, so they have zero
+ * cost on sites without Jetpack.
+ */
+class JetpackCompat {
+
+	public static function init(): void {
+		if ( ! defined( 'JETPACK__VERSION' ) ) {
+			return;
+		}
+
+		// Prevent booking posts (personal data) from syncing to WordPress.com via Jetpack Sync.
+		add_filter( 'jetpack_sync_blacklisted_post_types', array( static::class, 'excludePrivatePostTypesFromSync' ) );
+
+		// Prevent Jetpack Photon image CDN from rewriting URLs of map marker assets served
+		// from the plugin directory — Photon cannot proxy non-media-library files and would
+		// produce broken image URLs.
+		add_filter( 'jetpack_photon_skip_for_url', array( static::class, 'skipPhotonForMapAssets' ), 10, 2 );
+
+		// Prevent Jetpack Image Accelerator from lazy-loading images inside CB map containers.
+		// Leaflet populates these containers dynamically via JS; adding the lazy attribute
+		// before render causes tiles and markers to never load.
+		add_filter( 'jetpack_lazy_images_blacklisted_classes', array( static::class, 'skipLazyImagesInMapContainers' ) );
+	}
+
+	/**
+	 * Exclude cb_booking and cb_restriction from Jetpack Sync so that personal booking
+	 * data is not transmitted to WordPress.com infrastructure.
+	 *
+	 * @param string[] $post_types
+	 * @return string[]
+	 */
+	public static function excludePrivatePostTypesFromSync( array $post_types ): array {
+		$post_types[] = 'cb_booking';
+		$post_types[] = 'cb_restriction';
+		return $post_types;
+	}
+
+	/**
+	 * Skip Jetpack Photon for URLs pointing to CB plugin asset directories.
+	 * Photon only handles media-library images; trying to proxy plugin asset URLs
+	 * results in broken references.
+	 *
+	 * @param bool   $skip
+	 * @param string $image_url
+	 * @return bool
+	 */
+	public static function skipPhotonForMapAssets( bool $skip, string $image_url ): bool {
+		if ( $skip ) {
+			return $skip;
+		}
+		// CB map assets are served from the plugin directory, not the uploads directory.
+		if ( strpos( $image_url, 'commonsbooking' ) !== false && strpos( $image_url, '/plugins/' ) !== false ) {
+			return true;
+		}
+		return $skip;
+	}
+
+	/**
+	 * Add CB map container classes to the Jetpack Lazy Images class blacklist so
+	 * that images inside Leaflet map wrappers are never lazy-loaded by Jetpack.
+	 *
+	 * @param string[] $blacklisted_classes
+	 * @return string[]
+	 */
+	public static function skipLazyImagesInMapContainers( array $blacklisted_classes ): array {
+		$blacklisted_classes[] = 'cb-map-container';
+		$blacklisted_classes[] = 'leaflet-container';
+		return $blacklisted_classes;
+	}
+}

--- a/src/Wordpress/Compat/SeoCompat.php
+++ b/src/Wordpress/Compat/SeoCompat.php
@@ -11,6 +11,9 @@ namespace CommonsBooking\Wordpress\Compat;
  */
 class SeoCompat {
 
+	/**
+	 * Registers SEO plugin compatibility filters. Binds only when Yoast or Rank Math is active.
+	 */
 	public static function init(): void {
 		// Yoast SEO
 		if ( defined( 'WPSEO_VERSION' ) ) {
@@ -29,7 +32,7 @@ class SeoCompat {
 	 * so that title/meta templates and the SEO score feature work for item and
 	 * location pages.
 	 *
-	 * @param array $post_types
+	 * @param array $post_types Post types Yoast SEO already considers accessible.
 	 * @return array
 	 */
 	public static function addCbPostTypesToYoast( array $post_types ): array {
@@ -43,8 +46,8 @@ class SeoCompat {
 	 * Without this the sitemaps only cover built-in post types plus types that
 	 * have has_archive set, which CB's CPTs do not.
 	 *
-	 * @param array  $args      WP_Query args used by Yoast to fetch posts.
-	 * @param string $post_type The post type currently being processed.
+	 * @param array  $args      WP_Query args Yoast uses to fetch posts for the sitemap.
+	 * @param string $post_type The post type currently being processed by the sitemap builder.
 	 * @return array
 	 */
 	public static function allowCbPostTypesInYoastSitemap( array $args, string $post_type ): array {
@@ -58,14 +61,14 @@ class SeoCompat {
 	/**
 	 * Tell Rank Math to include cb_item and cb_location in its XML sitemap.
 	 *
-	 * @param bool   $include
-	 * @param string $post_type
+	 * @param bool   $enabled   Whether Rank Math already includes this post type in the sitemap.
+	 * @param string $post_type The post type being evaluated by the sitemap builder.
 	 * @return bool
 	 */
-	public static function addCbPostTypesToRankMathSitemap( bool $include, string $post_type ): bool {
+	public static function addCbPostTypesToRankMathSitemap( bool $enabled, string $post_type ): bool {
 		if ( in_array( $post_type, [ 'cb_item', 'cb_location' ], true ) ) {
 			return true;
 		}
-		return $include;
+		return $enabled;
 	}
 }

--- a/src/Wordpress/Compat/SeoCompat.php
+++ b/src/Wordpress/Compat/SeoCompat.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace CommonsBooking\Wordpress\Compat;
+
+/**
+ * Compatibility layer for popular SEO plugins.
+ *
+ * Registers cb_item and cb_location with Yoast SEO and Rank Math so that
+ * item and location pages are included in XML sitemaps and receive proper
+ * SEO meta tags. The filters only bind when the respective plugin is active.
+ */
+class SeoCompat {
+
+	public static function init(): void {
+		// Yoast SEO
+		if ( defined( 'WPSEO_VERSION' ) ) {
+			add_filter( 'wpseo_accessible_post_types', array( static::class, 'addCbPostTypesToYoast' ) );
+			add_filter( 'wpseo_sitemap_post_types_query_args', array( static::class, 'allowCbPostTypesInYoastSitemap' ), 10, 2 );
+		}
+
+		// Rank Math
+		if ( defined( 'RANK_MATH_VERSION' ) ) {
+			add_filter( 'rank_math/sitemap/post_type', array( static::class, 'addCbPostTypesToRankMathSitemap' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Register cb_item and cb_location as accessible post types with Yoast SEO
+	 * so that title/meta templates and the SEO score feature work for item and
+	 * location pages.
+	 *
+	 * @param array $post_types
+	 * @return array
+	 */
+	public static function addCbPostTypesToYoast( array $post_types ): array {
+		$post_types['cb_item']     = get_post_type_object( 'cb_item' );
+		$post_types['cb_location'] = get_post_type_object( 'cb_location' );
+		return array_filter( $post_types ); // remove nulls if CPTs not registered yet
+	}
+
+	/**
+	 * Ensure Yoast's sitemap generator includes cb_item and cb_location posts.
+	 * Without this the sitemaps only cover built-in post types plus types that
+	 * have has_archive set, which CB's CPTs do not.
+	 *
+	 * @param array  $args      WP_Query args used by Yoast to fetch posts.
+	 * @param string $post_type The post type currently being processed.
+	 * @return array
+	 */
+	public static function allowCbPostTypesInYoastSitemap( array $args, string $post_type ): array {
+		if ( in_array( $post_type, [ 'cb_item', 'cb_location' ], true ) ) {
+			// Force published posts to appear regardless of archive setting.
+			$args['post_status'] = 'publish';
+		}
+		return $args;
+	}
+
+	/**
+	 * Tell Rank Math to include cb_item and cb_location in its XML sitemap.
+	 *
+	 * @param bool   $include
+	 * @param string $post_type
+	 * @return bool
+	 */
+	public static function addCbPostTypesToRankMathSitemap( bool $include, string $post_type ): bool {
+		if ( in_array( $post_type, [ 'cb_item', 'cb_location' ], true ) ) {
+			return true;
+		}
+		return $include;
+	}
+}

--- a/src/Wordpress/Gutenberg/BlockPatterns.php
+++ b/src/Wordpress/Gutenberg/BlockPatterns.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace CommonsBooking\Wordpress\Gutenberg;
+
+/**
+ * Registers Gutenberg block patterns for CommonsBooking shortcodes.
+ *
+ * Patterns appear in the block inserter under the "CommonsBooking" category,
+ * making it easy for editors to insert booking features without knowing shortcode
+ * syntax. Each pattern wraps a shortcode in a Classic block, which is the
+ * zero-JavaScript approach — no React code needed.
+ */
+class BlockPatterns {
+
+	public static function init(): void {
+		add_action( 'init', array( static::class, 'registerPatternCategory' ) );
+		add_action( 'init', array( static::class, 'registerPatterns' ) );
+	}
+
+	public static function registerPatternCategory(): void {
+		if ( ! function_exists( 'register_block_pattern_category' ) ) {
+			return;
+		}
+		register_block_pattern_category(
+			'commonsbooking',
+			[ 'label' => __( 'CommonsBooking', 'commonsbooking' ) ]
+		);
+	}
+
+	public static function registerPatterns(): void {
+		if ( ! function_exists( 'register_block_pattern' ) ) {
+			return;
+		}
+
+		register_block_pattern(
+			'commonsbooking/search-map',
+			[
+				'title'       => __( 'CommonsBooking: Search & Map', 'commonsbooking' ),
+				'description' => __( 'Interactive map with search filters showing all bookable items and locations.', 'commonsbooking' ),
+				'categories'  => [ 'commonsbooking' ],
+				'content'     => '<!-- wp:shortcode -->[cb_search]<!-- /wp:shortcode -->',
+			]
+		);
+
+		register_block_pattern(
+			'commonsbooking/map',
+			[
+				'title'       => __( 'CommonsBooking: Map', 'commonsbooking' ),
+				'description' => __( 'Simple map displaying all configured locations.', 'commonsbooking' ),
+				'categories'  => [ 'commonsbooking' ],
+				'content'     => '<!-- wp:shortcode -->[cb_map]<!-- /wp:shortcode -->',
+			]
+		);
+
+		register_block_pattern(
+			'commonsbooking/my-bookings',
+			[
+				'title'       => __( 'CommonsBooking: My Bookings', 'commonsbooking' ),
+				'description' => __( "Shows the current user's booking list (upcoming and past bookings).", 'commonsbooking' ),
+				'categories'  => [ 'commonsbooking' ],
+				'content'     => '<!-- wp:shortcode -->[cb_bookings]<!-- /wp:shortcode -->',
+			]
+		);
+
+		register_block_pattern(
+			'commonsbooking/items-calendar',
+			[
+				'title'       => __( 'CommonsBooking: Items Calendar Table', 'commonsbooking' ),
+				'description' => __( 'Calendar-style availability overview for all items at all locations.', 'commonsbooking' ),
+				'categories'  => [ 'commonsbooking' ],
+				'content'     => '<!-- wp:shortcode -->[cb_items_table]<!-- /wp:shortcode -->',
+			]
+		);
+	}
+}

--- a/src/Wordpress/Gutenberg/BlockPatterns.php
+++ b/src/Wordpress/Gutenberg/BlockPatterns.php
@@ -12,11 +12,17 @@ namespace CommonsBooking\Wordpress\Gutenberg;
  */
 class BlockPatterns {
 
+	/**
+	 * Registers the block pattern category and all shortcode-based patterns on init.
+	 */
 	public static function init(): void {
 		add_action( 'init', array( static::class, 'registerPatternCategory' ) );
 		add_action( 'init', array( static::class, 'registerPatterns' ) );
 	}
 
+	/**
+	 * Registers the "CommonsBooking" block pattern category with WordPress.
+	 */
 	public static function registerPatternCategory(): void {
 		if ( ! function_exists( 'register_block_pattern_category' ) ) {
 			return;
@@ -27,6 +33,9 @@ class BlockPatterns {
 		);
 	}
 
+	/**
+	 * Registers all CommonsBooking shortcode-based block patterns.
+	 */
 	public static function registerPatterns(): void {
 		if ( ! function_exists( 'register_block_pattern' ) ) {
 			return;


### PR DESCRIPTION
- JetpackCompat: exclude cb_booking/cb_restriction from Jetpack Sync
  (personal booking data should not be transmitted to WordPress.com),
  skip Jetpack Photon for plugin asset URLs, and exclude Leaflet map
  containers from lazy-image rewriting (Leaflet populates these via JS)

- SeoCompat: register cb_item and cb_location with Yoast SEO and Rank
  Math so item/location pages appear in XML sitemaps and receive proper
  title/meta template support

- BlockPatterns: register a "CommonsBooking" block pattern category and
  four patterns (Search & Map, Map, My Bookings, Items Calendar) in the
  Gutenberg block inserter — each wraps an existing shortcode in a Classic
  block, requiring no JS

- Polylang: switch email language to the recipient's preferred Polylang
  language before building the mail body in Message::prepareMail(), and
  reset to the site default after sending — mirrors the existing WPML
  integration

All hooks are guarded by feature-detection checks (defined/function_exists)
so there is zero overhead on sites without these plugins.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U9JLgmjagwqfagmzF5EJMt