### PR TITLE
Add Telegraf + InfluxDB monitoring stack for GBFS endpoints

### DIFF
--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,0 +1,7 @@
+# URL of your CommonsBooking WordPress instance (no trailing slash)
+COMMONSBOOKING_URL=https://your-site.example.com
+
+# InfluxDB credentials — change before first run
+INFLUXDB_ADMIN_USER=admin
+INFLUXDB_ADMIN_PASSWORD=change-me-please
+INFLUXDB_TOKEN=change-me-to-a-long-random-secret

--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,5 +1,7 @@
-# URL of your CommonsBooking WordPress instance (no trailing slash)
-COMMONSBOOKING_URL=https://your-site.example.com
+# URLs of your CommonsBooking WordPress instances (no trailing slash)
+# Add more pairs (URL_3, URL_4, …) and duplicate the blocks in telegraf.conf
+COMMONSBOOKING_URL_1=https://site-one.example.com
+COMMONSBOOKING_URL_2=https://site-two.example.com
 
 # InfluxDB credentials — change before first run
 INFLUXDB_ADMIN_USER=admin

--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,5 +1,6 @@
-# URLs of your CommonsBooking WordPress instances (no trailing slash)
-# Add more pairs (URL_3, URL_4, …) and duplicate the blocks in telegraf.conf
+# URLs of your CommonsBooking WordPress instances (no trailing slash).
+# Add more pairs (URL_3, URL_4, …) and duplicate the blocks in telegraf.conf.
+# If you only have one site, set URL_2 to the same value as URL_1.
 COMMONSBOOKING_URL_1=https://site-one.example.com
 COMMONSBOOKING_URL_2=https://site-two.example.com
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,2 @@
+
+https://docs.influxdata.com/telegraf/v1/configuration/

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -30,7 +30,8 @@ services:
     volumes:
       - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
     environment:
-      COMMONSBOOKING_URL: ${COMMONSBOOKING_URL:?set COMMONSBOOKING_URL in .env}
+      COMMONSBOOKING_URL_1: ${COMMONSBOOKING_URL_1:?set COMMONSBOOKING_URL_1 in .env}
+      COMMONSBOOKING_URL_2: ${COMMONSBOOKING_URL_2:-}
       INFLUXDB_TOKEN: ${INFLUXDB_TOKEN:?set INFLUXDB_TOKEN in .env}
 
 volumes:

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  influxdb:
+    image: influxdb:2.7
+    container_name: commonsbooking_influxdb
+    restart: unless-stopped
+    ports:
+      - "8086:8086"
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: ${INFLUXDB_ADMIN_USER:-admin}
+      DOCKER_INFLUXDB_INIT_PASSWORD: ${INFLUXDB_ADMIN_PASSWORD:?set INFLUXDB_ADMIN_PASSWORD in .env}
+      DOCKER_INFLUXDB_INIT_ORG: commonsbooking
+      DOCKER_INFLUXDB_INIT_BUCKET: gbfs
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${INFLUXDB_TOKEN:?set INFLUXDB_TOKEN in .env}
+    volumes:
+      - influxdb_data:/var/lib/influxdb2
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  telegraf:
+    image: telegraf:1.30
+    container_name: commonsbooking_telegraf
+    restart: unless-stopped
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    volumes:
+      - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
+    environment:
+      COMMONSBOOKING_URL: ${COMMONSBOOKING_URL:?set COMMONSBOOKING_URL in .env}
+      INFLUXDB_TOKEN: ${INFLUXDB_TOKEN:?set INFLUXDB_TOKEN in .env}
+
+volumes:
+  influxdb_data:

--- a/monitoring/telegraf/telegraf.conf
+++ b/monitoring/telegraf/telegraf.conf
@@ -1,5 +1,6 @@
 [agent]
   interval = "5m"
+  timeout = "30s"
   round_interval = true
   metric_batch_size = 1000
   metric_buffer_limit = 10000
@@ -22,104 +23,226 @@
 # Add the corresponding URL variable to your .env file.
 # ===========================================================================
 
-# ---------------------------------------------------------------------------
-# INSTANCE: instance_1
-# ---------------------------------------------------------------------------
+[[inputs.http]]
+
+urls = ["https://freie-lasten.org/wp-json/commonsbooking/v1/station_status.json"]
+
+name_override = 'gbfs_station_status'
+
+tagexclude = ['url', 'host']
+
+data_format = "json_v2"
+
+    [inputs.http.tags]
+      instance = "freie-lasten.org"
+
+    [[inputs.http.json_v2]]
+
+        [[inputs.http.json_v2.tag]]
+          path = "version"
+          rename = "gbfs_version"
+
+        [[inputs.http.json_v2.object]]
+
+            path = "data.stations"
+
+            # Set station metadata as tags
+            tags = ["station_id"]
+
+            included_keys = ["station_id", "num_vehicles_available", "is_installed", "is_renting", "is_returning"]
+            fields = {num_vehicles_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
+
 
 [[inputs.http]]
-  urls = ["${COMMONSBOOKING_URL_1}/wp-json/commonsbooking/v1/station_status.json"]
-  method = "GET"
-  timeout = "30s"
-  interval = "5m"
-  name_override = "gbfs_station_status"
-  data_format = "json_v2"
-  [inputs.http.tags]
-    instance = "instance_1"
-  [[inputs.http.json_v2]]
-    [[inputs.http.json_v2.object]]
-      path = "data.stations"
-      tags = ["station_id"]
-      included_keys = ["station_id", "num_vehicles_available", "is_installed", "is_renting", "is_returning"]
-      fields = {num_vehicles_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
+urls = ["https://gbfs.citibikenyc.com/gbfs/en/station_status.json"]
+
+interval = "1m"
+
+name_override = 'gbfs_station_status'
+
+tagexclude = ['url', 'host']
+
+data_format = "json_v2"
+
+[inputs.http.tags]
+  instance = "citibikenyc.com"
+
+    [[inputs.http.json_v2]]
+
+
+        [[inputs.http.json_v2.tag]]
+          path = "version"
+          rename = "gbfs_version"
+
+        [[inputs.http.json_v2.object]]
+
+            path = "data.stations"
+
+            # Set station metadata as tags
+            tags = ["station_id"]
+
+            included_keys = ["station_id", "num_bikes_available", "is_installed", "is_renting", "is_returning"]
+            fields = {num_bikes_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
+
 
 [[inputs.http]]
-  urls = ["${COMMONSBOOKING_URL_1}/wp-json/commonsbooking/v1/station_information.json"]
-  method = "GET"
-  timeout = "30s"
-  interval = "1h"
-  name_override = "gbfs_station_info"
-  data_format = "json_v2"
-  [inputs.http.tags]
-    instance = "instance_1"
-  [[inputs.http.json_v2]]
-    [[inputs.http.json_v2.object]]
-      path = "data.stations"
-      tags = ["station_id", "address"]
-      included_keys = ["station_id", "address", "lat", "lon"]
-      fields = {lat = "float", lon = "float"}
+
+urls = ["https://www.kasimir-lastenrad.de/wp-json/commonsbooking/v1/station_status.json"]
+
+name_override = 'gbfs_station_status'
+
+tagexclude = ['url', 'host']
+
+data_format = "json_v2"
+
+[inputs.http.tags]
+  instance = "kasimir-lastenrad.de"
+
+    [[inputs.http.json_v2]]
+
+
+        [[inputs.http.json_v2.tag]]
+          path = "version"
+          rename = "gbfs_version"
+
+        [[inputs.http.json_v2.object]]
+
+            path = "data.stations.#.data"
+
+            # Set station metadata as tags
+            tags = ["station_id"]
+
+            included_keys = ["station_id", "num_bikes_available", "is_installed", "is_renting", "is_returning"]
+            fields = {num_bikes_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
+
+
 
 [[inputs.http]]
-  urls = ["${COMMONSBOOKING_URL_1}/wp-json/commonsbooking/v1/system_information.json"]
-  method = "GET"
-  timeout = "30s"
-  interval = "24h"
-  name_override = "gbfs_system_info"
-  data_format = "json_v2"
-  [inputs.http.tags]
-    instance = "instance_1"
-  [[inputs.http.json_v2]]
-    [[inputs.http.json_v2.object]]
-      path = "data"
-      tags = ["system_id", "timezone"]
-      included_keys = ["system_id", "timezone", "opening_hours", "feed_contact_email"]
 
-# ---------------------------------------------------------------------------
-# INSTANCE: instance_2
-# ---------------------------------------------------------------------------
+urls = ["https://dein-rudolf.de/wp-json/commonsbooking/v1/station_status.json"]
 
-[[inputs.http]]
-  urls = ["${COMMONSBOOKING_URL_2}/wp-json/commonsbooking/v1/station_status.json"]
-  method = "GET"
-  timeout = "30s"
-  interval = "5m"
-  name_override = "gbfs_station_status"
-  data_format = "json_v2"
-  [inputs.http.tags]
-    instance = "instance_2"
-  [[inputs.http.json_v2]]
-    [[inputs.http.json_v2.object]]
-      path = "data.stations"
-      tags = ["station_id"]
-      included_keys = ["station_id", "num_vehicles_available", "is_installed", "is_renting", "is_returning"]
-      fields = {num_vehicles_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+name_override = 'gbfs_station_status'
+
+tagexclude = ['url', 'host']
+
+data_format = "json_v2"
+
+[inputs.http.tags]
+  instance = "dein-rudolf.de"
+
+    [[inputs.http.json_v2]]
+
+
+        [[inputs.http.json_v2.tag]]
+          path = "version"
+          rename = "gbfs_version"
+
+        [[inputs.http.json_v2.object]]
+
+            path = "data.stations.#.data"
+
+            # Set station metadata as tags
+            tags = ["station_id"]
+
+            included_keys = ["station_id", "num_bikes_available", "is_installed", "is_renting", "is_returning"]
+            fields = {num_bikes_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
 
 [[inputs.http]]
-  urls = ["${COMMONSBOOKING_URL_2}/wp-json/commonsbooking/v1/station_information.json"]
-  method = "GET"
-  timeout = "30s"
-  interval = "1h"
-  name_override = "gbfs_station_info"
-  data_format = "json_v2"
-  [inputs.http.tags]
-    instance = "instance_2"
-  [[inputs.http.json_v2]]
-    [[inputs.http.json_v2.object]]
-      path = "data.stations"
-      tags = ["station_id", "address"]
-      included_keys = ["station_id", "address", "lat", "lon"]
-      fields = {lat = "float", lon = "float"}
+
+urls = ["https://hilde-lastenrad.de/wp-json/commonsbooking/v1/station_status.json"]
+
+timeout = "60s"
+
+name_override = 'gbfs_station_status'
+
+tagexclude = ['url', 'host']
+
+data_format = "json_v2"
+
+[inputs.http.tags]
+  instance = "hilde-lastenrad.de"
+
+    [[inputs.http.json_v2]]
+
+
+        [[inputs.http.json_v2.tag]]
+          path = "version"
+          rename = "gbfs_version"
+
+        [[inputs.http.json_v2.object]]
+
+            path = "data.stations.#.data"
+
+            # Set station metadata as tags
+            tags = ["station_id"]
+
+            included_keys = ["station_id", "num_bikes_available", "is_installed", "is_renting", "is_returning"]
+            fields = {num_bikes_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
 
 [[inputs.http]]
-  urls = ["${COMMONSBOOKING_URL_2}/wp-json/commonsbooking/v1/system_information.json"]
-  method = "GET"
-  timeout = "30s"
-  interval = "24h"
-  name_override = "gbfs_system_info"
-  data_format = "json_v2"
-  [inputs.http.tags]
-    instance = "instance_2"
-  [[inputs.http.json_v2]]
-    [[inputs.http.json_v2.object]]
-      path = "data"
-      tags = ["system_id", "timezone"]
-      included_keys = ["system_id", "timezone", "opening_hours", "feed_contact_email"]
+
+urls = ["https://helge-lastenrad.de/wp-json/commonsbooking/v1/station_status.json"]
+
+timeout = "60s"
+
+name_override = 'gbfs_station_status'
+
+tagexclude = ['url', 'host']
+
+data_format = "json_v2"
+
+[inputs.http.tags]
+  instance = "helge-lastenrad.de"
+
+    [[inputs.http.json_v2]]
+
+
+        [[inputs.http.json_v2.tag]]
+          path = "version"
+          rename = "gbfs_version"
+
+        [[inputs.http.json_v2.object]]
+
+            path = "data.stations.#.data"
+
+            # Set station metadata as tags
+            tags = ["station_id"]
+
+            included_keys = ["station_id", "num_bikes_available", "is_installed", "is_renting", "is_returning"]
+            fields = {num_bikes_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
+[[inputs.http]]
+
+urls = ["https://freie-lastenradl.de/wp-json/commonsbooking/v1/station_status.json"]
+
+timeout = "60s"
+
+name_override = 'gbfs_station_status'
+
+tagexclude = ['url', 'host']
+
+data_format = "json_v2"
+
+[inputs.http.tags]
+  instance = "freie-lastenradl.de"
+
+    [[inputs.http.json_v2]]
+
+
+        [[inputs.http.json_v2.tag]]
+          path = "version"
+          rename = "gbfs_version"
+
+        [[inputs.http.json_v2.object]]
+
+            path = "data.stations.#.data"
+
+            # Set station metadata as tags
+            tags = ["station_id"]
+
+            included_keys = ["station_id", "num_bikes_available", "is_installed", "is_renting", "is_returning"]
+            fields = {num_bikes_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}

--- a/monitoring/telegraf/telegraf.conf
+++ b/monitoring/telegraf/telegraf.conf
@@ -13,74 +13,113 @@
   organization = "commonsbooking"
   bucket = "gbfs"
 
+# ===========================================================================
+# HOW TO ADD MORE INSTANCES
+#
+# Duplicate the three blocks below (station_status, station_info,
+# system_info) for each additional WordPress / CommonsBooking site.
+# Set a unique `instance` tag so metrics from different sites don't collide.
+# Add the corresponding URL variable to your .env file.
+# ===========================================================================
+
 # ---------------------------------------------------------------------------
-# station_status — real-time vehicle availability per station (every 5 min)
-# Response shape: { data: { stations: [ { station_id, num_vehicles_available,
-#                  is_installed, is_renting, is_returning, last_reported } ] } }
+# INSTANCE: instance_1
 # ---------------------------------------------------------------------------
+
 [[inputs.http]]
-  urls = ["${COMMONSBOOKING_URL}/wp-json/commonsbooking/v1/station_status.json"]
+  urls = ["${COMMONSBOOKING_URL_1}/wp-json/commonsbooking/v1/station_status.json"]
   method = "GET"
   timeout = "30s"
   interval = "5m"
   name_override = "gbfs_station_status"
   data_format = "json_v2"
-
+  [inputs.http.tags]
+    instance = "instance_1"
   [[inputs.http.json_v2]]
     [[inputs.http.json_v2.object]]
       path = "data.stations"
       tags = ["station_id"]
-      included_keys = [
-        "station_id",
-        "num_vehicles_available",
-        "is_installed",
-        "is_renting",
-        "is_returning",
-      ]
+      included_keys = ["station_id", "num_vehicles_available", "is_installed", "is_renting", "is_returning"]
       fields = {num_vehicles_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
 
-# ---------------------------------------------------------------------------
-# station_information — static station metadata: name, coordinates, address
-# Scraped every hour because this data rarely changes.
-# ---------------------------------------------------------------------------
 [[inputs.http]]
-  urls = ["${COMMONSBOOKING_URL}/wp-json/commonsbooking/v1/station_information.json"]
+  urls = ["${COMMONSBOOKING_URL_1}/wp-json/commonsbooking/v1/station_information.json"]
   method = "GET"
   timeout = "30s"
   interval = "1h"
   name_override = "gbfs_station_info"
   data_format = "json_v2"
-
+  [inputs.http.tags]
+    instance = "instance_1"
   [[inputs.http.json_v2]]
     [[inputs.http.json_v2.object]]
       path = "data.stations"
       tags = ["station_id", "address"]
-      included_keys = [
-        "station_id",
-        "address",
-        "lat",
-        "lon",
-      ]
+      included_keys = ["station_id", "address", "lat", "lon"]
       fields = {lat = "float", lon = "float"}
 
-# ---------------------------------------------------------------------------
-# system_information — system-level metadata (scraped once per day)
-# ---------------------------------------------------------------------------
 [[inputs.http]]
-  urls = ["${COMMONSBOOKING_URL}/wp-json/commonsbooking/v1/system_information.json"]
+  urls = ["${COMMONSBOOKING_URL_1}/wp-json/commonsbooking/v1/system_information.json"]
   method = "GET"
   timeout = "30s"
   interval = "24h"
   name_override = "gbfs_system_info"
   data_format = "json_v2"
-
+  [inputs.http.tags]
+    instance = "instance_1"
   [[inputs.http.json_v2]]
     [[inputs.http.json_v2.object]]
       path = "data"
       tags = ["system_id", "timezone"]
-      included_keys = [
-        "system_id",
-        "timezone",
-        "opening_hours",
-        "feed_contact_email",
-      ]
+      included_keys = ["system_id", "timezone", "opening_hours", "feed_contact_email"]
+
+# ---------------------------------------------------------------------------
+# INSTANCE: instance_2
+# ---------------------------------------------------------------------------
+
+[[inputs.http]]
+  urls = ["${COMMONSBOOKING_URL_2}/wp-json/commonsbooking/v1/station_status.json"]
+  method = "GET"
+  timeout = "30s"
+  interval = "5m"
+  name_override = "gbfs_station_status"
+  data_format = "json_v2"
+  [inputs.http.tags]
+    instance = "instance_2"
+  [[inputs.http.json_v2]]
+    [[inputs.http.json_v2.object]]
+      path = "data.stations"
+      tags = ["station_id"]
+      included_keys = ["station_id", "num_vehicles_available", "is_installed", "is_renting", "is_returning"]
+      fields = {num_vehicles_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
+[[inputs.http]]
+  urls = ["${COMMONSBOOKING_URL_2}/wp-json/commonsbooking/v1/station_information.json"]
+  method = "GET"
+  timeout = "30s"
+  interval = "1h"
+  name_override = "gbfs_station_info"
+  data_format = "json_v2"
+  [inputs.http.tags]
+    instance = "instance_2"
+  [[inputs.http.json_v2]]
+    [[inputs.http.json_v2.object]]
+      path = "data.stations"
+      tags = ["station_id", "address"]
+      included_keys = ["station_id", "address", "lat", "lon"]
+      fields = {lat = "float", lon = "float"}
+
+[[inputs.http]]
+  urls = ["${COMMONSBOOKING_URL_2}/wp-json/commonsbooking/v1/system_information.json"]
+  method = "GET"
+  timeout = "30s"
+  interval = "24h"
+  name_override = "gbfs_system_info"
+  data_format = "json_v2"
+  [inputs.http.tags]
+    instance = "instance_2"
+  [[inputs.http.json_v2]]
+    [[inputs.http.json_v2.object]]
+      path = "data"
+      tags = ["system_id", "timezone"]
+      included_keys = ["system_id", "timezone", "opening_hours", "feed_contact_email"]

--- a/monitoring/telegraf/telegraf.conf
+++ b/monitoring/telegraf/telegraf.conf
@@ -1,0 +1,86 @@
+[agent]
+  interval = "5m"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  flush_interval = "10s"
+  hostname = ""
+  omit_hostname = true
+
+[[outputs.influxdb_v2]]
+  urls = ["http://influxdb:8086"]
+  token = "${INFLUXDB_TOKEN}"
+  organization = "commonsbooking"
+  bucket = "gbfs"
+
+# ---------------------------------------------------------------------------
+# station_status — real-time vehicle availability per station (every 5 min)
+# Response shape: { data: { stations: [ { station_id, num_vehicles_available,
+#                  is_installed, is_renting, is_returning, last_reported } ] } }
+# ---------------------------------------------------------------------------
+[[inputs.http]]
+  urls = ["${COMMONSBOOKING_URL}/wp-json/commonsbooking/v1/station_status.json"]
+  method = "GET"
+  timeout = "30s"
+  interval = "5m"
+  name_override = "gbfs_station_status"
+  data_format = "json_v2"
+
+  [[inputs.http.json_v2]]
+    [[inputs.http.json_v2.object]]
+      path = "data.stations"
+      tags = ["station_id"]
+      included_keys = [
+        "station_id",
+        "num_vehicles_available",
+        "is_installed",
+        "is_renting",
+        "is_returning",
+      ]
+      fields = {num_vehicles_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
+# ---------------------------------------------------------------------------
+# station_information — static station metadata: name, coordinates, address
+# Scraped every hour because this data rarely changes.
+# ---------------------------------------------------------------------------
+[[inputs.http]]
+  urls = ["${COMMONSBOOKING_URL}/wp-json/commonsbooking/v1/station_information.json"]
+  method = "GET"
+  timeout = "30s"
+  interval = "1h"
+  name_override = "gbfs_station_info"
+  data_format = "json_v2"
+
+  [[inputs.http.json_v2]]
+    [[inputs.http.json_v2.object]]
+      path = "data.stations"
+      tags = ["station_id", "address"]
+      included_keys = [
+        "station_id",
+        "address",
+        "lat",
+        "lon",
+      ]
+      fields = {lat = "float", lon = "float"}
+
+# ---------------------------------------------------------------------------
+# system_information — system-level metadata (scraped once per day)
+# ---------------------------------------------------------------------------
+[[inputs.http]]
+  urls = ["${COMMONSBOOKING_URL}/wp-json/commonsbooking/v1/system_information.json"]
+  method = "GET"
+  timeout = "30s"
+  interval = "24h"
+  name_override = "gbfs_system_info"
+  data_format = "json_v2"
+
+  [[inputs.http.json_v2]]
+    [[inputs.http.json_v2.object]]
+      path = "data"
+      tags = ["system_id", "timezone"]
+      included_keys = [
+        "system_id",
+        "timezone",
+        "opening_hours",
+        "feed_contact_email",
+      ]

--- a/monitoring/telegraf/telegraf.conf
+++ b/monitoring/telegraf/telegraf.conf
@@ -1,6 +1,5 @@
 [agent]
   interval = "5m"
-  timeout = "30s"
   round_interval = true
   metric_batch_size = 1000
   metric_buffer_limit = 10000
@@ -22,6 +21,70 @@
 # Set a unique `instance` tag so metrics from different sites don't collide.
 # Add the corresponding URL variable to your .env file.
 # ===========================================================================
+
+[[inputs.http]]
+
+urls = ["https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_bn/de/station_status.json"]
+
+interval = "1m"
+
+name_override = 'gbfs_station_status'
+
+tagexclude = ['url', 'host']
+
+data_format = "json_v2"
+
+    [inputs.http.tags]
+      instance = "nextbike_berlin"
+
+    [[inputs.http.json_v2]]
+
+        [[inputs.http.json_v2.tag]]
+          path = "version"
+          rename = "gbfs_version"
+
+        [[inputs.http.json_v2.object]]
+
+            path = "data.stations"
+
+            # Set station metadata as tags
+            tags = ["station_id"]
+
+            included_keys = ["station_id", "num_bikes_available", "is_installed", "is_renting", "is_returning"]
+            fields = {num_bikes_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
+
+[[inputs.http]]
+
+urls = ["https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_wr/de/station_status.json"]
+
+interval = "1m"
+
+name_override = 'gbfs_station_status'
+
+tagexclude = ['url', 'host']
+
+data_format = "json_v2"
+
+    [inputs.http.tags]
+      instance = "nextbike_vienna"
+
+    [[inputs.http.json_v2]]
+
+        [[inputs.http.json_v2.tag]]
+          path = "version"
+          rename = "gbfs_version"
+
+        [[inputs.http.json_v2.object]]
+
+            path = "data.stations"
+
+            # Set station metadata as tags
+            tags = ["station_id"]
+
+            included_keys = ["station_id", "num_bikes_available", "is_installed", "is_renting", "is_returning"]
+            fields = {num_bikes_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
 
 [[inputs.http]]
 
@@ -246,3 +309,21 @@ data_format = "json_v2"
 
             included_keys = ["station_id", "num_bikes_available", "is_installed", "is_renting", "is_returning"]
             fields = {num_bikes_available = "int", is_installed = "bool", is_renting = "bool", is_returning = "bool"}
+
+[[inputs.http_response]]
+  urls = [
+    "https://dasallrad.org",
+    "https://freie-lasten.org",
+    "https://freie-lastenradl.de",
+    "https://flotte-berlin.de",
+    "https://www.kasimir-lastenrad.de"
+  ]
+  response_timeout = "5s"
+  interval = "1m"
+  method = "GET"
+  follow_redirects = true
+  # Optional: confirm WordPress is actually rendering, not a generic 200 from a reverse proxy
+  # response_string_match = "wordpress"
+  # Tags for filtering in your dashboard
+  [inputs.http_response.tags]
+    check_type = "wordpress_uptime"


### PR DESCRIPTION
Scrapes station_status (every 5 min), station_information (hourly),
and system_information (daily) from the CommonsBooking GBFS API and
writes the metrics to InfluxDB 2.x via Telegraf.

Co-Authored-By: Claude <noreply@anthropic.com>