### PR TITLE
Add "Open Data & Interoperability" docs section

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -240,6 +240,9 @@ export function sidebarDocs_de(): DefaultTheme.SidebarItem[] {
               { text: 'GBFS', link: 'gbfs'}
           ]
       },
+      {
+          text: 'Offene Daten & Interoperabilität', link: '/de/documentation/open-data/'
+      },
 
     {
       text: 'Erweiterte Funktionalität', base: '/de/documentation/advanced-functionality/',
@@ -376,6 +379,9 @@ export function sidebarDocs_en(): DefaultTheme.SidebarItem[] {
               { text: 'Using the CommonsBooking API', link: 'commonsbooking-api' },
               { text: 'GBFS', link: 'gbfs' }
           ]
+      },
+      {
+          text: 'Open Data & Interoperability', link: '/en/documentation/open-data/'
       },
     {
       text: 'Advanced functionality', base: '/en/documentation/advanced-functionality/',

--- a/docs/de/documentation/api/index.md
+++ b/docs/de/documentation/api/index.md
@@ -7,3 +7,5 @@ Das CommonsBooking Plugin stellt verschiedene Schnittstellen bereit, für die Nu
 * [ GBFS ](gbfs)
 
 Zusätzlich kannst du auch die [Standard Wordpress REST-API](https://developer.wordpress.org/rest-api) mit etwas technischem Verständnis nutzen.
+
+Falls du eine allgemeinverständliche Zusammenfassung dieser Schnittstellen für Interessenvertretung, Forschung oder Industrie suchst, siehe [Offene Daten & Interoperabilität](../open-data/).

--- a/docs/de/documentation/open-data/index.md
+++ b/docs/de/documentation/open-data/index.md
@@ -1,0 +1,43 @@
+# Offene Daten & Interoperabilität
+
+CommonsBooking betreibt eine große und wachsende Zahl nicht-kommerzieller Lastenrad-Verleih- und
+Leihladen-Initiativen in ganz Europa. Für Verbände, Forschende, politische Entscheidungsträger:innen und
+Interessenvertretungen im Bereich Shared Mobility bietet das Plugin nicht nur die lokale Buchungsverwaltung
+— es veröffentlicht diese Aktivität auch über offene, standardisierte Schnittstellen, sodass sie
+aggregiert, ausgewertet und in größere Mobilitätsdaten-Ökosysteme eingebunden werden kann.
+
+Diese Seite fasst die dafür relevanten Schnittstellen zusammen. Technische Details und Einrichtung findest
+du in der [Schnittstellen / API](../api/) Dokumentation.
+
+## GBFS (General Bikeshare Feed Specification)
+
+Seit Version 2.5 kann CommonsBooking Stations-, Artikel- und Echtzeit-Verfügbarkeitsdaten über
+[GBFS](https://www.gbfs.org/documentation/) veröffentlichen — den offenen Standard, den Bikesharing-Systeme,
+MaaS-Apps und städtische/regionale Mobilitätsdatenplattformen nutzen, um geteilte Fahrzeugflotten
+einzubinden. Damit können gemeinschaftlich betriebene Lastenrad-Flotten grundsätzlich in denselben
+Datenpipelines wie kommerzielle Bikesharing-Systeme erscheinen.
+
+→ [GBFS-Dokumentation](../api/gbfs)
+
+## Die CommonsAPI
+
+Die CommonsAPI ist ein eigens entwickeltes, offenes Schema, um einzelne CommonsBooking-Installationen mit
+zentralen, organisationsübergreifenden Plattformen zu verbinden — zum Beispiel bundesweiten Verzeichnissen
+verfügbarer Lastenräder. Sie stellt standardisierte Daten zu Trägerorganisationen (Projekten), Stationen,
+Artikeln und deren Verfügbarkeit bereit.
+
+→ [Was ist die CommonsAPI?](../api/what-is-the-commonsapi)
+→ [CommonsBooking API nutzen](../api/commonsbooking-api)
+
+## Größenordnung und Community-Kontext
+
+CommonsBooking entstand aus den Initiativen der "Freien Lastenräder" in Köln und bildet heute die
+technische Grundlage für den [Verband Freie Lastenräder e.V.](https://freies-lastenrad.org/verband/) (VFL),
+der mehr als 100 freie Lastenrad-Initiativen listet. Hintergrundinfos gibt es auf der
+[Über uns](../../about/) Seite.
+
+## Kontakt
+
+Wenn deine Organisation an Datenstandards für Shared Mobility, Lastenrad-Interessenvertretung oder
+Forschung arbeitet und Interesse an einer Anbindung oder Zusammenarbeit hat, melde dich gerne über unsere
+[Kontaktseite](../../contact).

--- a/docs/en/documentation/api/index.md
+++ b/docs/en/documentation/api/index.md
@@ -7,3 +7,5 @@ The CommonsBooking plugin provides various interfaces for using the data or inte
 * [GBFS](gbfs)
 
 Additionally, you can also use the [standard WordPress REST API](https://developer.wordpress.org/rest-api) with some technical understanding.
+
+If you're looking for a non-technical summary of these interfaces for advocacy, research or industry purposes, see [Open Data & Interoperability](../open-data/).

--- a/docs/en/documentation/open-data/index.md
+++ b/docs/en/documentation/open-data/index.md
@@ -1,0 +1,40 @@
+# Open Data & Interoperability
+
+CommonsBooking powers a large and growing number of non-commercial cargo-bike-sharing and tool-lending
+initiatives across Europe. For associations, researchers, policymakers and industry bodies interested in
+shared mobility, the plugin doesn't just run bookings locally — it also publishes that activity through
+open, standards-based interfaces, so it can be aggregated, analyzed and integrated into wider
+mobility-data ecosystems.
+
+This page summarizes the interfaces relevant to that kind of work. For technical/setup details, follow the
+links into the [Extensions / API](../api/) documentation.
+
+## GBFS (General Bikeshare Feed Specification)
+
+Since version 2.5, CommonsBooking can publish location, item and real-time availability data using
+[GBFS](https://www.gbfs.org/documentation/), the open standard used by bike-share systems, MaaS apps and
+city/regional mobility-data platforms to ingest shared-vehicle fleets. This means community-run cargo-bike
+fleets can, in principle, show up alongside commercial bike-share systems in the same data pipelines.
+
+→ [GBFS documentation](../api/gbfs)
+
+## The Commons-API
+
+The Commons-API is a purpose-built open schema for connecting individual CommonsBooking installations to
+central, cross-organization platforms — for example nationwide directories of available cargo bikes. It
+exposes standardized data about lending organizations (projects), locations, items and their availability.
+
+→ [What is the CommonsAPI?](../api/what-is-the-commonsapi)
+→ [Using the CommonsBooking API](../api/commonsbooking-api)
+
+## Scale and community context
+
+CommonsBooking originated with the "Free Cargo Bikes" initiatives in Cologne, Germany, and today underpins
+the umbrella association [Verband Freie Lastenräder e.V.](https://freies-lastenrad.org/verband/) (VFL),
+which lists more than 100 free cargo-bike initiatives. See the [About](../../about/) page for background.
+
+## Get in touch
+
+If your organization works on shared-mobility data standards, cargo-bike advocacy, or research, and you'd
+like to talk about integrating with or building on this data, please reach out via our
+[contact page](../../contact).


### PR DESCRIPTION
Summarizes GBFS and Commons-API support for advocacy/industry/research
audiences, linking into the existing Extensions/API detail pages.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mw4LfMmC5FRiME31TPk29r