### PR TITLE
Add extensibility hooks for item/location lifecycle and scoped queries

### DIFF
--- a/includes/Users.php
+++ b/includes/Users.php
@@ -261,15 +261,28 @@ function commonsbooking_isCurrentUserAllowedToBook( $timeframeID ): bool {
 	$allowedUserRoles = get_post_meta( $timeframeID, \CommonsBooking\Model\Timeframe::META_ALLOWED_USER_ROLES, true );
 
 	if ( empty( $allowedUserRoles ) || ( commonsbooking_isCurrentUserAdmin() ) ) {
-		return true;
+		$isAllowed = true;
+	} else {
+		$current_user = wp_get_current_user();
+		$user_roles   = $current_user->roles;
+
+		$match = array_intersect( $user_roles, $allowedUserRoles );
+
+		$isAllowed = count( $match ) > 0;
 	}
 
-	$current_user = wp_get_current_user();
-	$user_roles   = $current_user->roles;
-
-	$match = array_intersect( $user_roles, $allowedUserRoles );
-
-	return count( $match ) > 0;
+	/**
+	 * Filters whether the current user is allowed to book the given timeframe.
+	 * Runs in addition to the role-based check above, so external code (e.g. an integration
+	 * that restricts booking eligibility to members of some external group/community) can
+	 * grant or revoke booking permission without having to model that as a WordPress role.
+	 *
+	 * @since 2.11.0
+	 *
+	 * @param bool  $isAllowed   true or false, if current user is allowed to book the timeframe based on the role check
+	 * @param mixed $timeframeID id of the timeframe that is checked
+	 */
+	return apply_filters( 'commonsbooking_isCurrentUserAllowedToBook', $isAllowed, $timeframeID );
 }
 
 /**

--- a/src/Model/Booking.php
+++ b/src/Model/Booking.php
@@ -111,6 +111,15 @@ class Booking extends \CommonsBooking\Model\Timeframe {
 
 		update_post_meta( $this->post->ID, 'cancellation_time', current_time( 'timestamp' ) );
 
+		/**
+		 * Fires once after a booking has been cancelled.
+		 *
+		 * @since 2.11.0
+		 *
+		 * @param Booking $booking the cancelled booking
+		 */
+		do_action( 'commonsbooking_booking_cancelled', $this );
+
 		$this->sendCancellationMail();
 	}
 

--- a/src/Repository/BookablePost.php
+++ b/src/Repository/BookablePost.php
@@ -231,19 +231,36 @@ abstract class BookablePost extends PostRepository {
 			unset( $args['category_slug'] );
 		}
 
-		$customCacheKey = md5( serialize( $args ) );
+		$defaults = array(
+			'post_status' => array( 'publish', 'inherit' ),
+			'nopaging'    => true,
+		);
+
+		$queryArgs = wp_parse_args( $args, $defaults );
+
+		/**
+		 * Filters the WP_Query arguments used to fetch items/locations.
+		 * Allows external code to scope the returned items/locations by an arbitrary
+		 * criterion (e.g. a postmeta value tying a post to an external group/community)
+		 * instead of only the built-in taxonomy filtering, without having to reimplement
+		 * or duplicate this query. Applies to both Item::get() and Location::get(), which
+		 * is also what backs the map, the cb_items/cb_locations shortcodes and the REST API.
+		 *
+		 * @since 2.11.0
+		 *
+		 * @param array  $queryArgs WP_Query arguments that are about to be used
+		 * @param string $postType  post type being queried, e.g. cb_item or cb_location
+		 * @param bool   $bookable  whether the query is restricted to bookable posts
+		 */
+		$queryArgs = apply_filters( 'commonsbooking_repository_query_args', $queryArgs, static::getPostType(), $bookable );
+
+		$customCacheKey = md5( serialize( $queryArgs ) );
 
 		$cacheItem = Plugin::getCacheItem( $customCacheKey );
 		if ( $cacheItem ) {
 			return $cacheItem;
 		} else {
-			$defaults = array(
-				'post_status' => array( 'publish', 'inherit' ),
-				'nopaging'    => true,
-			);
-
-			$queryArgs = wp_parse_args( $args, $defaults );
-			$query     = new WP_Query( $queryArgs );
+			$query = new WP_Query( $queryArgs );
 
 			if ( $query->have_posts() ) {
 				$posts = $query->get_posts();

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -344,7 +344,6 @@ class Booking extends Timeframe {
 
 			$postId          = wp_insert_post( $postarr, true );
 			$needsValidation = true;
-			$isNewBooking    = true;
 
 			// Existing booking
 		} else {
@@ -360,7 +359,6 @@ class Booking extends Timeframe {
 			} else {
 				$needsValidation = false;
 			}
-			$isNewBooking = false;
 		}
 
 		self::saveGridSizes( $postId, $locationId, $itemId, $repetitionStart, $repetitionEnd );
@@ -394,17 +392,6 @@ class Booking extends Timeframe {
 				__( 'There was an error while saving the booking. Please try again. Resulting WP_ERROR: ', 'commonsbooking' ) .
 												PHP_EOL . implode( ', ', $postId->get_error_messages() )
 			);
-		}
-
-		if ( $isNewBooking ) {
-			/**
-			 * Fires once after a new booking has been created via the frontend booking flow.
-			 *
-			 * @since 2.11.0
-			 *
-			 * @param \CommonsBooking\Model\Booking $booking the newly created booking
-			 */
-			do_action( 'commonsbooking_booking_created', $bookingModel );
 		}
 
 		return $postId;
@@ -520,17 +507,6 @@ class Booking extends Timeframe {
 					} else {
 						$booking_msg = new BookingMessage( $post_ID, $post_after->post_status );
 						$booking_msg->triggerMail();
-
-						if ( $post_after->post_status === 'confirmed' ) {
-							/**
-							 * Fires once after a booking has been confirmed.
-							 *
-							 * @since 2.11.0
-							 *
-							 * @param \CommonsBooking\Model\Booking $booking the confirmed booking
-							 */
-							do_action( 'commonsbooking_booking_confirmed', new \CommonsBooking\Model\Booking( $post_ID ) );
-						}
 					}
 				}
 			}

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -344,6 +344,7 @@ class Booking extends Timeframe {
 
 			$postId          = wp_insert_post( $postarr, true );
 			$needsValidation = true;
+			$isNewBooking    = true;
 
 			// Existing booking
 		} else {
@@ -359,6 +360,7 @@ class Booking extends Timeframe {
 			} else {
 				$needsValidation = false;
 			}
+			$isNewBooking = false;
 		}
 
 		self::saveGridSizes( $postId, $locationId, $itemId, $repetitionStart, $repetitionEnd );
@@ -392,6 +394,17 @@ class Booking extends Timeframe {
 				__( 'There was an error while saving the booking. Please try again. Resulting WP_ERROR: ', 'commonsbooking' ) .
 												PHP_EOL . implode( ', ', $postId->get_error_messages() )
 			);
+		}
+
+		if ( $isNewBooking ) {
+			/**
+			 * Fires once after a new booking has been created via the frontend booking flow.
+			 *
+			 * @since 2.11.0
+			 *
+			 * @param \CommonsBooking\Model\Booking $booking the newly created booking
+			 */
+			do_action( 'commonsbooking_booking_created', $bookingModel );
 		}
 
 		return $postId;
@@ -507,6 +520,17 @@ class Booking extends Timeframe {
 					} else {
 						$booking_msg = new BookingMessage( $post_ID, $post_after->post_status );
 						$booking_msg->triggerMail();
+
+						if ( $post_after->post_status === 'confirmed' ) {
+							/**
+							 * Fires once after a booking has been confirmed.
+							 *
+							 * @since 2.11.0
+							 *
+							 * @param \CommonsBooking\Model\Booking $booking the confirmed booking
+							 */
+							do_action( 'commonsbooking_booking_confirmed', new \CommonsBooking\Model\Booking( $post_ID ) );
+						}
 					}
 				}
 			}

--- a/src/Wordpress/CustomPostType/Item.php
+++ b/src/Wordpress/CustomPostType/Item.php
@@ -29,7 +29,7 @@ class Item extends CustomPostType {
 		add_action( 'pre_get_posts', array( $this, 'filterAdminList' ) );
 
 		// Save-handling
-		add_action( 'save_post', array( $this, 'savePost' ), 11, 2 );
+		add_action( 'save_post', array( $this, 'savePost' ), 11, 3 );
 	}
 
 	/**
@@ -50,11 +50,26 @@ class Item extends CustomPostType {
 
 	/**
 	 * Handles save-Request for items.
+	 *
+	 * @param int      $post_id
+	 * @param \WP_Post $post
+	 * @param bool     $update true if this is an update of an existing item, false if the item was just created
 	 */
-	public function savePost( $post_id, \WP_Post $post ) {
+	public function savePost( $post_id, \WP_Post $post, $update = true ) {
 		if ( $post->post_type == self::$postType && $post_id ) {
 			// update all dynamic timeframes
 			Timeframe::updateAllTimeframes();
+
+			if ( ! $update && $post->post_status !== 'auto-draft' ) {
+				/**
+				 * Fires once after a new item has been created.
+				 *
+				 * @since 2.11.0
+				 *
+				 * @param \CommonsBooking\Model\Item $item the newly created item
+				 */
+				do_action( 'commonsbooking_item_created', new \CommonsBooking\Model\Item( $post ) );
+			}
 		}
 	}
 

--- a/src/Wordpress/CustomPostType/Location.php
+++ b/src/Wordpress/CustomPostType/Location.php
@@ -27,7 +27,7 @@ class Location extends CustomPostType {
 		add_action( 'pre_get_posts', array( $this, 'filterAdminList' ) );
 
 		// Save-handling
-		add_action( 'save_post', array( $this, 'savePost' ), 11, 2 );
+		add_action( 'save_post', array( $this, 'savePost' ), 11, 3 );
 	}
 
 	protected static function getTaxonomyArgs() {
@@ -42,14 +42,29 @@ class Location extends CustomPostType {
 
 	/**
 	 * Handles save-Request for location.
+	 *
+	 * @param int      $post_id
+	 * @param \WP_Post $post
+	 * @param bool     $update true if this is an update of an existing location, false if the location was just created
 	 */
-	public function savePost( $post_id, \WP_Post $post ) {
+	public function savePost( $post_id, \WP_Post $post, $update = true ) {
 		if ( $post->post_type == self::$postType && $post_id ) {
 			$location = new \CommonsBooking\Model\Location( intval( $post_id ) );
 			$location->updateGeoLocation();
 
 			// update all dynamic timeframes
 			Timeframe::updateAllTimeframes();
+
+			if ( ! $update && $post->post_status !== 'auto-draft' ) {
+				/**
+				 * Fires once after a new location has been created.
+				 *
+				 * @since 2.11.0
+				 *
+				 * @param \CommonsBooking\Model\Location $location the newly created location
+				 */
+				do_action( 'commonsbooking_location_created', $location );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Small, independent extensibility additions identified while assessing what it would take to integrate CommonsBooking with an external community/group system (e.g. BuddyPress) without forking core logic. Each is its own commit:

- **Lifecycle action hooks** (`b1322fc`, trimmed by `4f5c5fc`): adds `commonsbooking_booking_cancelled`, `commonsbooking_item_created` and `commonsbooking_location_created`. Previously the only custom hook in the plugin was `commonsbooking_mail_sent`, so external code had no reliable way to react to these state transitions without hooking generic `save_post`/`post_updated` and re-deriving the "what changed" logic itself. Each hook fires at the single existing point in the codebase where that transition already happens (`Model\Booking::cancel()`, `Item::savePost()`, `Location::savePost()`).

  > **Note:** this originally also added `commonsbooking_booking_created` / `commonsbooking_booking_confirmed`, but #12 (open, unmerged) already adds both at the same call sites with a richer `($postId, $booking)` signature. Commit `4f5c5fc` drops the duplicates from this PR to avoid double-firing with incompatible signatures once both land — #12 is the source of truth for those two hooks.

- **Filterable booking eligibility** (`c79ea5f`): `commonsbooking_isCurrentUserAllowedToBook()` now applies a `commonsbooking_isCurrentUserAllowedToBook` filter to its result, matching the existing pattern used by `commonsbooking_isCurrentUserAdmin` / `commonsbooking_isCurrentUserCBManager`. Today, restricting a timeframe to members of some external group means minting a dedicated WordPress role per group, which doesn't scale. The filter lets external code layer additional eligibility logic on top of the existing role check.

- **Scoped Item/Location queries** (`88187e4`): `BookablePost::get()` (shared by `Item::get()`/`Location::get()`, and therefore also the map, the `cb_items`/`cb_locations` shortcodes and the REST API) now applies a `commonsbooking_repository_query_args` filter to the `WP_Query` args before running the query. This lets external code scope results by an arbitrary criterion (e.g. a postmeta value tying a post to an externally-managed group) instead of only the built-in category taxonomy. The query cache key is derived from the *filtered* args rather than the raw input args, so context-dependent scoping (e.g. "current group") can't return stale results cached for a different context.

None of these change default behavior — they only add hook points that no-op until something attaches a callback.

## Test plan

- [x] `php -l` on all changed files
- [x] Confirmed no other overlap with #12 (only touches `Booking.php` + 2 templates; my remaining hooks touch `Model/Booking.php`, `Item.php`, `Location.php`, `includes/Users.php`, `Repository/BookablePost.php`)
- [ ] CI (PHPUnit/PHPCS) — no local PHP toolchain (composer/vendor) available in this environment to run it beforehand
- [ ] Manual smoke test: attach a callback to each new hook/filter in a throwaway mu-plugin and confirm it fires at the expected point (booking cancellation, item/location creation, item/location listing)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EsHRoXca6Px2WjLHNYfKYn)_