### PR TITLE
Add scheduled periodic plain-text booking report email

### DIFF
--- a/includes/OptionsArray.php
+++ b/includes/OptionsArray.php
@@ -1226,6 +1226,57 @@ This item has been booked by {{user:first_name}} {{user:last_name}} ( {{user:use
 				),
 			),
 			/* field group booking end reminder for locations end */
+
+			/* field group periodic booking report */
+			'booking-report' => array(
+				'title'  => commonsbooking_sanitizeHTML( __( 'Periodic booking report', 'commonsbooking' ) ),
+				'id'     => 'booking-report',
+				'desc'   => commonsbooking_sanitizeHTML(
+					__(
+						'You can set here whether a plain-text report with booking numbers should be sent by e-mail on a regular basis. The report contains the number of confirmed bookings (counted by booking start date) for the last 7 days, 30 days and 3 months, each compared to the preceding period. The report is sent around 04:00 in the morning: weekly on Mondays or on the first day of the month.',
+						'commonsbooking'
+					)
+				),
+				'fields' => array(
+					// settings booking report -- activate
+					array(
+						'name' => esc_html__( 'Activate', 'commonsbooking' ),
+						'id'   => 'booking-report-activate',
+						'type' => 'checkbox',
+					),
+					// settings booking report -- interval
+					array(
+						'name'             => esc_html__( 'Interval', 'commonsbooking' ),
+						'id'               => 'booking-report-interval',
+						'desc'             => '<br>' . commonsbooking_sanitizeHTML(
+							__(
+								'Choose how often the report should be sent. Weekly reports are sent on Mondays, monthly reports on the first day of the month.',
+								'commonsbooking'
+							)
+						),
+						'type'             => 'select',
+						'show_option_none' => false,
+						'default'          => 'weekly',
+						'options'          => array(
+							'weekly'  => esc_html__( 'Weekly', 'commonsbooking' ),
+							'monthly' => esc_html__( 'Monthly', 'commonsbooking' ),
+						),
+					),
+					// settings booking report -- recipient
+					array(
+						'name'       => esc_html__( 'Recipient e-mail address', 'commonsbooking' ),
+						'id'         => 'booking-report-recipient',
+						'desc'       => '<br>' . commonsbooking_sanitizeHTML(
+							__(
+								'The e-mail address the report should be sent to. If left empty, the site administration e-mail address is used.',
+								'commonsbooking'
+							)
+						),
+						'type'       => 'text_email',
+					),
+				),
+			),
+			/* field group periodic booking report end */
 		),
 		/* field group container end */
 	),

--- a/src/Repository/Booking.php
+++ b/src/Repository/Booking.php
@@ -277,6 +277,61 @@ class Booking extends PostRepository {
 	}
 
 	/**
+	 * Counts confirmed bookings whose booking period starts within the given timerange.
+	 *
+	 * The count is based on the booking's start date (repetition-start), so a booking is
+	 * counted for the period in which it takes place, regardless of when it was created.
+	 * Only bookings with post status "confirmed" are counted.
+	 *
+	 * @param int $startDate Start of the timerange (unix timestamp, inclusive).
+	 * @param int $endDate   End of the timerange (unix timestamp, inclusive).
+	 *
+	 * @return int Number of confirmed bookings starting within the timerange.
+	 * @throws Exception
+	 */
+	public static function countBookingsStartingInRange( int $startDate, int $endDate ): int {
+		$args = array(
+			'post_type'   => \CommonsBooking\Wordpress\CustomPostType\Booking::$postType,
+			'meta_query'  => array(
+				'relation' => 'AND',
+				array(
+					'key'     => \CommonsBooking\Model\Timeframe::REPETITION_START,
+					'value'   => $startDate,
+					'compare' => '>=',
+					'type'    => 'numeric',
+				),
+				array(
+					'key'     => \CommonsBooking\Model\Timeframe::REPETITION_START,
+					'value'   => $endDate,
+					'compare' => '<=',
+					'type'    => 'numeric',
+				),
+				array(
+					'key'     => 'type',
+					'value'   => Timeframe::BOOKING_ID,
+					'compare' => '=',
+				),
+			),
+			'post_status' => array( 'confirmed' ),
+			'fields'      => 'ids',
+			'nopaging'    => true,
+		);
+
+		$query = new WP_Query( $args );
+
+		// post_status filtering in the query is not reliable for our custom
+		// statuses, so we re-check it explicitly (see getModelsFromQuery()).
+		$count = 0;
+		foreach ( $query->posts as $postId ) {
+			if ( get_post_status( $postId ) === 'confirmed' ) {
+				$count++;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
 	 * Returns all bookings, allowed to see for user.
 	 *
 	 * @param bool     $asModel if true, returns as Booking array, if false, return int array (defaults to false)

--- a/src/Service/BookingReport.php
+++ b/src/Service/BookingReport.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace CommonsBooking\Service;
+
+use CommonsBooking\Repository\Booking;
+use CommonsBooking\Settings\Settings;
+
+/**
+ * Builds and sends a periodic, plain-text booking report by e-mail.
+ *
+ * The report contains the number of confirmed bookings (counted by their
+ * booking start date) for a set of trailing periods, each compared against
+ * the immediately preceding period of the same length:
+ * - last 7 days vs. the 7 days before
+ * - last 30 days vs. the 30 days before
+ * - last 3 months vs. the 3 months before
+ *
+ * Sending is scheduled daily (see Service\Scheduler) but the report is only
+ * actually sent on the configured interval (weekly on Mondays, monthly on the
+ * first day of the month). The daily scheduling is used because the scheduler
+ * only supports a fixed time of day for daily jobs.
+ */
+class BookingReport {
+
+	const OPTION_GROUP = 'commonsbooking_options_reminder';
+
+	/**
+	 * Entry point called by the scheduler once per day.
+	 *
+	 * Checks whether the report is activated and whether today is a sending day
+	 * for the configured interval, and sends the report if so.
+	 *
+	 * @return void
+	 */
+	public static function sendReport(): void {
+		if ( Settings::getOption( self::OPTION_GROUP, 'booking-report-activate' ) != 'on' ) {
+			return;
+		}
+
+		$interval = Settings::getOption( self::OPTION_GROUP, 'booking-report-interval' );
+		if ( ! self::isSendingDay( $interval, time() ) ) {
+			return;
+		}
+
+		$body    = self::getReportBody();
+		$subject = sprintf(
+			// translators: %s = site name
+			__( 'CommonsBooking booking report for %s', 'commonsbooking' ),
+			get_bloginfo( 'name' )
+		);
+
+		self::sendMail( $subject, $body );
+	}
+
+	/**
+	 * Determines whether the report should be sent today for the given interval.
+	 *
+	 * @param string   $interval "weekly" or "monthly".
+	 * @param int|null $now      Reference timestamp (defaults to current time). Used for testing.
+	 *
+	 * @return bool
+	 */
+	public static function isSendingDay( string $interval, ?int $now = null ): bool {
+		$now ??= time();
+
+		switch ( $interval ) {
+			case 'monthly':
+				// First day of the month.
+				return wp_date( 'j', $now ) === '1';
+			case 'weekly':
+			default:
+				// Monday (ISO-8601: 1 = Monday).
+				return wp_date( 'N', $now ) === '1';
+		}
+	}
+
+	/**
+	 * Builds the plain-text body of the report.
+	 *
+	 * @param int|null $now Reference timestamp (defaults to current time). Used for testing.
+	 *
+	 * @return string
+	 * @throws \Exception
+	 */
+	public static function getReportBody( ?int $now = null ): string {
+		$now ??= time();
+
+		$periods = array(
+			array(
+				'label' => __( 'Last 7 days', 'commonsbooking' ),
+				'prev'  => __( 'previous 7 days', 'commonsbooking' ),
+				'spec'  => '7 days',
+			),
+			array(
+				'label' => __( 'Last 30 days', 'commonsbooking' ),
+				'prev'  => __( 'previous 30 days', 'commonsbooking' ),
+				'spec'  => '30 days',
+			),
+			array(
+				'label' => __( 'Last 3 months', 'commonsbooking' ),
+				'prev'  => __( 'previous 3 months', 'commonsbooking' ),
+				'spec'  => '3 months',
+			),
+		);
+
+		$lines   = array();
+		$lines[] = sprintf(
+			// translators: %1$s = site name, %2$s = date
+			__( 'CommonsBooking - Booking report for %1$s (%2$s)', 'commonsbooking' ),
+			get_bloginfo( 'name' ),
+			wp_date( 'Y-m-d' )
+		);
+		$lines[] = '';
+		$lines[] = __( 'Number of confirmed bookings (counted by booking start date):', 'commonsbooking' );
+		$lines[] = '';
+
+		foreach ( $periods as $period ) {
+			$currentStart = strtotime( '-' . $period['spec'], $now );
+			$previousStart = strtotime( '-' . $period['spec'], $currentStart );
+
+			// Current period: (currentStart, now]. Previous period: (previousStart, currentStart].
+			$current  = Booking::countBookingsStartingInRange( $currentStart + 1, $now );
+			$previous = Booking::countBookingsStartingInRange( $previousStart + 1, $currentStart );
+
+			$lines[] = sprintf(
+				'  %-16s %6d   (%s: %d)',
+				$period['label'] . ':',
+				$current,
+				$period['prev'],
+				$previous
+			);
+		}
+
+		$lines[] = '';
+
+		return implode( "\n", $lines ) . "\n";
+	}
+
+	/**
+	 * Sends the report e-mail as plain text.
+	 *
+	 * @param string $subject
+	 * @param string $body
+	 *
+	 * @return bool Whether the mail was accepted for delivery by wp_mail().
+	 */
+	protected static function sendMail( string $subject, string $body ): bool {
+		$recipient = sanitize_email( Settings::getOption( self::OPTION_GROUP, 'booking-report-recipient' ) );
+		if ( empty( $recipient ) ) {
+			$recipient = get_option( 'admin_email' );
+		}
+
+		$fromName  = Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-name' );
+		$fromEmail = sanitize_email( Settings::getOption( 'commonsbooking_options_templates', 'emailheaders_from-email' ) );
+
+		$headers = array( 'Content-Type: text/plain; charset=UTF-8' );
+		if ( ! empty( $fromEmail ) ) {
+			$headers[] = sprintf( 'From: %s <%s>', $fromName, $fromEmail );
+		}
+
+		return wp_mail( $recipient, $subject, $body, $headers );
+	}
+}

--- a/src/Service/Scheduler.php
+++ b/src/Service/Scheduler.php
@@ -188,6 +188,18 @@ class Scheduler {
 			'today midnight +3 hour'
 		);
 
+		// Init periodic booking report job.
+		// Runs daily at 04:00; the report itself is only sent on the configured
+		// interval (weekly/monthly), see BookingReport::sendReport().
+		new Scheduler(
+			'booking_report',
+			array( \CommonsBooking\Service\BookingReport::class, 'sendReport' ),
+			'daily',
+			'today midnight +4 hour',
+			array( 'commonsbooking_options_reminder', 'booking-report-activate' ),
+			'update_option_commonsbooking_options_reminder'
+		);
+
 		// Init timeframe export job
 		$exportPath     = Settings::getOption( 'commonsbooking_options_export', 'export-filepath' );
 		$exportInterval = Settings::getOption( 'commonsbooking_options_export', 'export-interval' );

--- a/tests/php/Service/BookingReportTest.php
+++ b/tests/php/Service/BookingReportTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace CommonsBooking\Tests\Service;
+
+use CommonsBooking\Repository\Booking as BookingRepository;
+use CommonsBooking\Service\BookingReport;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+
+class BookingReportTest extends CustomPostTypeTest {
+
+	/**
+	 * Creates a confirmed booking that starts $daysAgo days before the reference date.
+	 */
+	private function createBookingStartingDaysAgo( int $daysAgo, string $postStatus = 'confirmed' ): int {
+		$start = strtotime( '-' . $daysAgo . ' days', strtotime( self::CURRENT_DATE ) );
+		$end   = strtotime( '+2 hours', $start );
+
+		return $this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			$start,
+			$end,
+			'8:00 AM',
+			'10:00 AM',
+			$postStatus
+		);
+	}
+
+	public function testCountBookingsStartingInRange() {
+		$now = strtotime( self::CURRENT_DATE );
+
+		// Within the last 7 days.
+		$this->createBookingStartingDaysAgo( 3 );
+		// Within the previous 7 days (8-14 days ago).
+		$this->createBookingStartingDaysAgo( 10 );
+		// Between 30 and 60 days ago.
+		$this->createBookingStartingDaysAgo( 40 );
+		// A canceled booking within the last 7 days must NOT be counted.
+		$this->createBookingStartingDaysAgo( 2, 'canceled' );
+
+		$last7  = BookingRepository::countBookingsStartingInRange( strtotime( '-7 days', $now ) + 1, $now );
+		$prev7  = BookingRepository::countBookingsStartingInRange( strtotime( '-14 days', $now ) + 1, strtotime( '-7 days', $now ) );
+		$last30 = BookingRepository::countBookingsStartingInRange( strtotime( '-30 days', $now ) + 1, $now );
+		$prev30 = BookingRepository::countBookingsStartingInRange( strtotime( '-60 days', $now ) + 1, strtotime( '-30 days', $now ) );
+
+		// Only the confirmed booking 3 days ago (canceled one is excluded).
+		$this->assertEquals( 1, $last7 );
+		// The booking 10 days ago.
+		$this->assertEquals( 1, $prev7 );
+		// Bookings 3 and 10 days ago.
+		$this->assertEquals( 2, $last30 );
+		// The booking 40 days ago.
+		$this->assertEquals( 1, $prev30 );
+	}
+
+	public function testGetReportBodyContainsCounts() {
+		$now = strtotime( self::CURRENT_DATE );
+
+		$this->createBookingStartingDaysAgo( 3 );  // last 7 days
+		$this->createBookingStartingDaysAgo( 10 ); // previous 7 days
+
+		$body = BookingReport::getReportBody( $now );
+
+		$this->assertStringContainsString( 'Last 7 days', $body );
+		$this->assertStringContainsString( 'Last 30 days', $body );
+		$this->assertStringContainsString( 'Last 3 months', $body );
+		// Last 7 days: 1 booking, previous 7 days: 1 booking.
+		$this->assertMatchesRegularExpression( '/Last 7 days:\s+1\s+\(previous 7 days: 1\)/', $body );
+		// Last 30 days: both bookings, previous 30 days: none.
+		$this->assertMatchesRegularExpression( '/Last 30 days:\s+2\s+\(previous 30 days: 0\)/', $body );
+	}
+
+	public function testIsSendingDayWeekly() {
+		// 2021-07-05 is a Monday.
+		$this->assertTrue( BookingReport::isSendingDay( 'weekly', strtotime( '2021-07-05 12:00:00' ) ) );
+		// 2021-07-06 is a Tuesday.
+		$this->assertFalse( BookingReport::isSendingDay( 'weekly', strtotime( '2021-07-06 12:00:00' ) ) );
+	}
+
+	public function testIsSendingDayMonthly() {
+		// First day of the month.
+		$this->assertTrue( BookingReport::isSendingDay( 'monthly', strtotime( '2021-07-01 12:00:00' ) ) );
+		// Not the first day of the month.
+		$this->assertFalse( BookingReport::isSendingDay( 'monthly', strtotime( '2021-07-02 12:00:00' ) ) );
+	}
+}


### PR DESCRIPTION
Adds a weekly or monthly plain-text report that is emailed around 04:00
in the morning. The report lists the number of confirmed bookings
(counted by booking start date) for the last 7 days, 30 days and 3
months, each compared against the immediately preceding period.

- New Service\BookingReport builds the plain-text body and sends it via
  wp_mail(). The scheduler runs the job daily at 04:00 and the report is
  only sent on the configured interval (weekly on Mondays, monthly on the
  first of the month), since Scheduler only supports a fixed time of day
  for daily recurrence.
- New Repository\Booking::countBookingsStartingInRange() counts confirmed
  bookings by their start date.
- New settings in the Reminder tab: activate, interval (weekly/monthly)
  and recipient email (defaults to the site admin email).
- Adds tests for the count query, report body and sending-day logic.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UCKGDj3J4aQTPefGhLsj1C