### PR TITLE
Add "Book again" / "Did you try …" booking recommendations

### DIFF
--- a/docs/de/documentation/administration/shortcodes.md
+++ b/docs/de/documentation/administration/shortcodes.md
@@ -138,3 +138,28 @@ User in der Rolle von Administrator*innen sehen hier alle Buchungen.
   * Import in digitalen Kalender über [iCalendar](../manage-bookings/icalendar-feed)-Format möglich
 
 ![](/img/shortcode-cb-bookings.png)
+
+## Buchungsempfehlungen ("Erneut buchen")
+
+Zeigt dem eingeloggten Nutzenden persönliche Empfehlungen an:
+
+  * **Erneut buchen**: Artikel, die der Nutzende bereits gebucht hat und die im
+    gewählten Zeitfenster aktuell frei sind.
+  * **Schon probiert …**: Artikel, die eine Kategorie mit den bisher gebuchten
+    Artikeln teilen und im selben Zeitfenster frei sind.
+
+Für nicht eingeloggte Nutzende oder wenn es nichts zu empfehlen gibt, gibt der
+Shortcode nichts aus.
+
+  * Shortcode: `[cb_book_again]`
+  * Parameter:
+    * `window`: Zu prüfendes Zeitfenster. Einer der Werte `today`, `tomorrow`
+      oder `week` (rollierende 7 Tage). Standard ist `week`.
+
+      Beispiel:
+      ```
+      [cb_book_again window=today]
+      ```
+    * `max`: Maximale Anzahl der Artikel pro Abschnitt (Standard `6`).
+    * `book-again`: Mit `no` wird der Abschnitt "Erneut buchen" ausgeblendet.
+    * `similar`: Mit `no` wird der Abschnitt "Schon probiert …" ausgeblendet.

--- a/docs/en/documentation/administration/shortcodes.md
+++ b/docs/en/documentation/administration/shortcodes.md
@@ -125,3 +125,24 @@ Users in the administrator role see all bookings here.
   * Import to digital calendar via [iCalendar](../manage-bookings/icalendar-feed) format possible
 
 ![](/img/shortcode-cb-bookings.png)
+
+## Booking recommendations ("Book again")
+
+Shows personalised recommendations for the logged-in user:
+
+  * **Book again**: items the user has booked before that currently have a free slot in the selected time window.
+  * **Did you try …**: items that share a category with the user's previously booked items and are free in the same window.
+
+The shortcode outputs nothing for logged-out users or when there is nothing to suggest.
+
+  * Shortcode: `[cb_book_again]`
+  * Parameters:
+    * `window`: Availability window to check. One of `today`, `tomorrow` or `week` (a rolling 7 days). Defaults to `week`.
+
+      Example:
+      ```
+      [cb_book_again window=today]
+      ```
+    * `max`: Maximum number of items to show per section (defaults to `6`).
+    * `book-again`: Set to `no` to hide the "Book again" section.
+    * `similar`: Set to `no` to hide the "Did you try …" section.

--- a/src/Service/BookingRecommendation.php
+++ b/src/Service/BookingRecommendation.php
@@ -1,0 +1,454 @@
+<?php
+
+namespace CommonsBooking\Service;
+
+use CommonsBooking\Helper\Wordpress;
+use CommonsBooking\Model\Booking;
+use CommonsBooking\Model\Day;
+use CommonsBooking\Plugin;
+use CommonsBooking\Repository\Timeframe as TimeframeRepository;
+use CommonsBooking\Wordpress\CustomPostType\Item;
+use CommonsBooking\Wordpress\CustomPostType\Timeframe as TimeframeCPT;
+use Exception;
+use WP_Post;
+use WP_Query;
+use WP_User;
+
+/**
+ * Builds "Book again" and "Did you try …" recommendations for a user.
+ *
+ * "Book again" suggests items the user has booked before that currently have a
+ * free bookable slot within a given time window (today, tomorrow or the next
+ * seven days). "Did you try …" suggests items that share a category (the item
+ * taxonomy) with the user's previously booked items and that are free in the
+ * same window.
+ *
+ * All availability decisions reuse the existing timeframe/booking logic via the
+ * {@see Day} model, so holidays, repairs, restrictions and existing bookings are
+ * respected the same way the booking calendar respects them.
+ */
+class BookingRecommendation {
+
+	/**
+	 * Free at some point today.
+	 */
+	const WINDOW_TODAY = 'today';
+
+	/**
+	 * Free at some point tomorrow.
+	 */
+	const WINDOW_TOMORROW = 'tomorrow';
+
+	/**
+	 * Free at some point within a rolling seven day window starting today.
+	 */
+	const WINDOW_WEEK = 'week';
+
+	/**
+	 * Returns the list of valid window identifiers.
+	 *
+	 * @return string[]
+	 */
+	public static function getWindows(): array {
+		return [ self::WINDOW_TODAY, self::WINDOW_TOMORROW, self::WINDOW_WEEK ];
+	}
+
+	/**
+	 * Returns [ startTimestamp, endTimestamp ] for the given window.
+	 *
+	 * The "week" window is a rolling seven days from now (not the ISO week).
+	 *
+	 * @param string $window
+	 *
+	 * @return int[]
+	 */
+	protected static function windowRange( string $window ): array {
+		$now = time();
+
+		switch ( $window ) {
+			case self::WINDOW_TOMORROW:
+				$start = (int) strtotime( 'tomorrow midnight', $now );
+				$end   = (int) strtotime( 'tomorrow 23:59:59', $now );
+				break;
+			case self::WINDOW_WEEK:
+				$start = (int) strtotime( 'midnight', $now );
+				$end   = $now + ( 7 * DAY_IN_SECONDS );
+				break;
+			case self::WINDOW_TODAY:
+			default:
+				$start = (int) strtotime( 'midnight', $now );
+				$end   = (int) strtotime( 'today 23:59:59', $now );
+				break;
+		}
+
+		return [ $start, $end ];
+	}
+
+	/**
+	 * Returns the distinct items a user has previously booked.
+	 *
+	 * Each entry is keyed by item id and contains the locations the user booked
+	 * the item at and the most recent booking start date (used for ranking).
+	 *
+	 * @param WP_User $user
+	 *
+	 * @return array<int, array{itemId:int, locationIds:int[], lastBooked:int}>
+	 * @throws Exception
+	 */
+	public static function getPreviousItemsForUser( WP_User $user ): array {
+		$bookings = \CommonsBooking\Repository\Booking::getForUser( $user, true );
+
+		$items = [];
+		foreach ( $bookings as $booking ) {
+			if ( ! ( $booking instanceof Booking ) ) {
+				continue;
+			}
+
+			$itemId = $booking->getItemID();
+			if ( ! $itemId ) {
+				continue;
+			}
+
+			// Only keep items that still exist and are published.
+			$itemPost = get_post( $itemId );
+			if (
+				! ( $itemPost instanceof WP_Post ) ||
+				$itemPost->post_type !== Item::getPostType() ||
+				$itemPost->post_status !== 'publish'
+			) {
+				continue;
+			}
+
+			if ( ! array_key_exists( $itemId, $items ) ) {
+				$items[ $itemId ] = [
+					'itemId'      => $itemId,
+					'locationIds' => [],
+					'lastBooked'  => 0,
+				];
+			}
+
+			$locationId = $booking->getLocationID();
+			if ( $locationId ) {
+				$items[ $itemId ]['locationIds'][ $locationId ] = $locationId;
+			}
+
+			$startDate = $booking->getStartDate();
+			if ( $startDate > $items[ $itemId ]['lastBooked'] ) {
+				$items[ $itemId ]['lastBooked'] = $startDate;
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Returns "Book again" suggestions: previously booked items that are free
+	 * within the given window.
+	 *
+	 * @param WP_User $user
+	 * @param string  $window One of the WINDOW_* constants.
+	 * @param int     $limit  Maximum number of suggestions.
+	 *
+	 * @return array<int, array{itemId:int, locationId:?int}>
+	 * @throws Exception
+	 */
+	public static function getBookAgainSuggestions( WP_User $user, string $window = self::WINDOW_WEEK, int $limit = 6 ): array {
+		$window = self::sanitizeWindow( $window );
+
+		$customId  = md5( __METHOD__ . $user->ID . $window . $limit );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem !== false ) {
+			return $cacheItem;
+		}
+
+		[ $start, $end ] = self::windowRange( $window );
+
+		$previousItems = self::getPreviousItemsForUser( $user );
+
+		// Rank by most recently booked first.
+		usort(
+			$previousItems,
+			function ( $a, $b ) {
+				return $b['lastBooked'] <=> $a['lastBooked'];
+			}
+		);
+
+		$suggestions   = [];
+		$itemIdsUsed   = [];
+		$locationsUsed = [];
+		foreach ( $previousItems as $entry ) {
+			$freeLocation = self::firstFreeLocation( $entry['itemId'], $entry['locationIds'], $start, $end );
+			if ( $freeLocation === null ) {
+				continue;
+			}
+
+			$suggestions[]   = [
+				'itemId'     => $entry['itemId'],
+				'locationId' => $freeLocation,
+			];
+			$itemIdsUsed[]   = $entry['itemId'];
+			$locationsUsed[] = $freeLocation;
+
+			if ( count( $suggestions ) >= $limit ) {
+				break;
+			}
+		}
+
+		Plugin::setCacheItem(
+			$suggestions,
+			Wordpress::getTags( [], $itemIdsUsed, $locationsUsed ),
+			$customId,
+			'midnight'
+		);
+
+		return $suggestions;
+	}
+
+	/**
+	 * Returns "Did you try …" suggestions: items sharing a category with the
+	 * user's previously booked items, that are free within the given window and
+	 * that the user has not booked before.
+	 *
+	 * @param WP_User $user
+	 * @param string  $window One of the WINDOW_* constants.
+	 * @param int     $limit  Maximum number of suggestions.
+	 *
+	 * @return array<int, array{itemId:int, locationId:?int}>
+	 * @throws Exception
+	 */
+	public static function getSimilarSuggestions( WP_User $user, string $window = self::WINDOW_WEEK, int $limit = 6 ): array {
+		$window = self::sanitizeWindow( $window );
+
+		$customId  = md5( __METHOD__ . $user->ID . $window . $limit );
+		$cacheItem = Plugin::getCacheItem( $customId );
+		if ( $cacheItem !== false ) {
+			return $cacheItem;
+		}
+
+		[ $start, $end ] = self::windowRange( $window );
+
+		$previousItems     = self::getPreviousItemsForUser( $user );
+		$previousItemIds   = array_keys( $previousItems );
+		$categoryTermIds   = self::getCategoryTermIds( $previousItemIds );
+
+		if ( empty( $categoryTermIds ) ) {
+			// Nothing to base similarity on.
+			Plugin::setCacheItem( [], [ 'misc' ], $customId, 'midnight' );
+			return [];
+		}
+
+		$candidateIds = self::getItemIdsByTerms( $categoryTermIds, $previousItemIds );
+
+		$suggestions   = [];
+		$itemIdsUsed   = [];
+		$locationsUsed = [];
+		foreach ( $candidateIds as $itemId ) {
+			$freeLocation = self::firstFreeLocation( $itemId, [], $start, $end );
+			if ( $freeLocation === null ) {
+				continue;
+			}
+
+			$suggestions[]   = [
+				'itemId'     => $itemId,
+				'locationId' => $freeLocation,
+			];
+			$itemIdsUsed[]   = $itemId;
+			$locationsUsed[] = $freeLocation;
+
+			if ( count( $suggestions ) >= $limit ) {
+				break;
+			}
+		}
+
+		Plugin::setCacheItem(
+			$suggestions,
+			Wordpress::getTags( [], $itemIdsUsed, $locationsUsed ),
+			$customId,
+			'midnight'
+		);
+
+		return $suggestions;
+	}
+
+	/**
+	 * Returns the first location id where the item has a free bookable slot in
+	 * the given range, or null if none is found.
+	 *
+	 * When no candidate locations are supplied, the item's bookable locations are
+	 * derived from its bookable timeframes.
+	 *
+	 * @param int   $itemId
+	 * @param int[] $locationIds
+	 * @param int   $start
+	 * @param int   $end
+	 *
+	 * @return int|null
+	 * @throws Exception
+	 */
+	protected static function firstFreeLocation( int $itemId, array $locationIds, int $start, int $end ): ?int {
+		if ( empty( $locationIds ) ) {
+			$locationIds = self::getBookableLocationIds( $itemId );
+		}
+
+		foreach ( $locationIds as $locationId ) {
+			if ( self::isFreeInRange( $itemId, (int) $locationId, $start, $end ) ) {
+				return (int) $locationId;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the location ids at which the item currently has bookable
+	 * timeframes (visible to the current user).
+	 *
+	 * @param int $itemId
+	 *
+	 * @return int[]
+	 * @throws Exception
+	 */
+	protected static function getBookableLocationIds( int $itemId ): array {
+		$timeframes = TimeframeRepository::getBookableForCurrentUser(
+			[],
+			[ $itemId ],
+			null,
+			true
+		);
+
+		$locationIds = [];
+		foreach ( $timeframes as $timeframe ) {
+			$locationId = $timeframe->getLocationID();
+			if ( $locationId ) {
+				$locationIds[ $locationId ] = $locationId;
+			}
+		}
+
+		return array_values( $locationIds );
+	}
+
+	/**
+	 * Determines whether the item has at least one free bookable slot at the
+	 * given location within [ $start, $end ].
+	 *
+	 * A slot counts as free when the highest-priority timeframe covering it is of
+	 * type "bookable" (existing bookings, holidays, repairs and restrictions win
+	 * over bookable timeframes in the {@see Day} grid), the slot ends in the
+	 * future and the timeframe is already bookable on that day.
+	 *
+	 * @param int $itemId
+	 * @param int $locationId
+	 * @param int $start
+	 * @param int $end
+	 *
+	 * @return bool
+	 * @throws Exception
+	 */
+	protected static function isFreeInRange( int $itemId, int $locationId, int $start, int $end ): bool {
+		$now = time();
+
+		$dayTimestamp = (int) strtotime( 'midnight', $start );
+		while ( $dayTimestamp <= $end ) {
+			$dateString = date( 'Y-m-d', $dayTimestamp );
+			$day        = new Day( $dateString, [ $locationId ], [ $itemId ] );
+
+			foreach ( $day->getGrid() as $slot ) {
+				if ( empty( $slot['timeframe'] ) || ! ( $slot['timeframe'] instanceof WP_Post ) ) {
+					continue;
+				}
+
+				// Only directly bookable slots count as free.
+				$type = get_post_meta( $slot['timeframe']->ID, 'type', true );
+				if ( (int) $type !== TimeframeCPT::BOOKABLE_ID ) {
+					continue;
+				}
+
+				// Slot must not lie fully in the past or after the window.
+				if ( $slot['timestampend'] <= $now || $slot['timestampstart'] > $end ) {
+					continue;
+				}
+
+				// Respect advance-booking rules (first bookable day of the timeframe).
+				$timeframe = new \CommonsBooking\Model\Timeframe( $slot['timeframe'] );
+				if ( $timeframe->getFirstBookableDay() > $dateString ) {
+					continue;
+				}
+
+				return true;
+			}
+
+			$dayTimestamp = (int) strtotime( '+1 day', $dayTimestamp );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Collects the item-category term ids assigned to the given items.
+	 *
+	 * @param int[] $itemIds
+	 *
+	 * @return int[]
+	 */
+	protected static function getCategoryTermIds( array $itemIds ): array {
+		$taxonomy = Item::getTaxonomyName();
+
+		$termIds = [];
+		foreach ( $itemIds as $itemId ) {
+			$terms = get_the_terms( $itemId, $taxonomy );
+			if ( is_array( $terms ) ) {
+				foreach ( $terms as $term ) {
+					$termIds[ $term->term_id ] = $term->term_id;
+				}
+			}
+		}
+
+		return array_values( $termIds );
+	}
+
+	/**
+	 * Returns published item ids that carry any of the given category terms,
+	 * excluding the supplied items.
+	 *
+	 * @param int[] $termIds
+	 * @param int[] $excludeItemIds
+	 *
+	 * @return int[]
+	 */
+	protected static function getItemIdsByTerms( array $termIds, array $excludeItemIds ): array {
+		if ( empty( $termIds ) ) {
+			return [];
+		}
+
+		$query = new WP_Query(
+			[
+				'post_type'      => Item::getPostType(),
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'post__not_in'   => array_map( 'intval', $excludeItemIds ),
+				'no_found_rows'  => true,
+				'tax_query'      => [
+					[
+						'taxonomy' => Item::getTaxonomyName(),
+						'field'    => 'term_id',
+						'terms'    => array_map( 'intval', $termIds ),
+					],
+				],
+			]
+		);
+
+		return array_map( 'intval', $query->posts );
+	}
+
+	/**
+	 * Falls back to the rolling week window for unknown input.
+	 *
+	 * @param string $window
+	 *
+	 * @return string
+	 */
+	protected static function sanitizeWindow( string $window ): string {
+		return in_array( $window, self::getWindows(), true ) ? $window : self::WINDOW_WEEK;
+	}
+}

--- a/src/View/BookAgain.php
+++ b/src/View/BookAgain.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace CommonsBooking\View;
+
+use CommonsBooking\Service\BookingRecommendation;
+use Exception;
+
+/**
+ * Frontend rendering for the "Book again" / "Did you try …" recommendations.
+ *
+ * Registered as the [cb_book_again] shortcode. The shortcode only outputs
+ * something for logged-in users and stays silent when there is nothing to
+ * suggest.
+ */
+class BookAgain extends View {
+
+	/**
+	 * Default shortcode attributes.
+	 *
+	 * @var array
+	 */
+	public static $allowedShortCodeArgs = [
+		'window'     => BookingRecommendation::WINDOW_WEEK,
+		'max'        => 6,
+		'book-again' => 'yes',
+		'similar'    => 'yes',
+	];
+
+	/**
+	 * Renders the [cb_book_again] shortcode.
+	 *
+	 * @param array|string $atts
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
+	public static function shortcode( $atts ): string {
+		if ( ! is_user_logged_in() ) {
+			return '';
+		}
+
+		$args = shortcode_atts(
+			static::$allowedShortCodeArgs,
+			$atts,
+			'cb_book_again'
+		);
+
+		$user   = wp_get_current_user();
+		$window = in_array( $args['window'], BookingRecommendation::getWindows(), true )
+			? $args['window']
+			: BookingRecommendation::WINDOW_WEEK;
+		$max    = max( 1, intval( $args['max'] ) );
+
+		$bookAgain = ( $args['book-again'] !== 'no' )
+			? BookingRecommendation::getBookAgainSuggestions( $user, $window, $max )
+			: [];
+
+		$similar = ( $args['similar'] !== 'no' )
+			? BookingRecommendation::getSimilarSuggestions( $user, $window, $max )
+			: [];
+
+		if ( empty( $bookAgain ) && empty( $similar ) ) {
+			return '';
+		}
+
+		global $templateData;
+		$templateData = [
+			'bookAgain' => $bookAgain,
+			'similar'   => $similar,
+			'window'    => $window,
+		];
+
+		ob_start();
+		commonsbooking_get_template_part( 'shortcode', 'book-again', true, false, false );
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Returns a human readable label for the free-availability window.
+	 *
+	 * @param string $window
+	 *
+	 * @return string
+	 */
+	public static function getWindowLabel( string $window ): string {
+		switch ( $window ) {
+			case BookingRecommendation::WINDOW_TODAY:
+				return __( 'free today', 'commonsbooking' );
+			case BookingRecommendation::WINDOW_TOMORROW:
+				return __( 'free tomorrow', 'commonsbooking' );
+			case BookingRecommendation::WINDOW_WEEK:
+			default:
+				return __( 'free within the next 7 days', 'commonsbooking' );
+		}
+	}
+}

--- a/src/Wordpress/CustomPostType/Booking.php
+++ b/src/Wordpress/CustomPostType/Booking.php
@@ -56,6 +56,9 @@ class Booking extends Timeframe {
 		// Listing of bookings for current user
 		add_shortcode( 'cb_bookings', array( \CommonsBooking\View\Booking::class, 'shortcode' ) );
 
+		// "Book again" / "Did you try …" recommendations for current user
+		add_shortcode( 'cb_book_again', array( \CommonsBooking\View\BookAgain::class, 'shortcode' ) );
+
 		// Add type filter to backend list view
 		// add_action( 'restrict_manage_posts', array( static::class, 'addAdminTypeFilter' ) );
 		add_action( 'restrict_manage_posts', array( static::class, 'addAdminItemFilter' ) );

--- a/templates/shortcode-book-again.php
+++ b/templates/shortcode-book-again.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Template: shortcode-book-again
+ * Shortcode [cb_book_again]
+ *
+ * Renders two lists of item suggestions for the current user:
+ *  - "Book again": items the user has booked before that are free in the window.
+ *  - "Did you try …": items sharing a category with the user's items, free too.
+ *
+ * Provided via global $templateData:
+ *  - bookAgain: array of [ 'itemId' => int, 'locationId' => ?int ]
+ *  - similar:   array of [ 'itemId' => int, 'locationId' => ?int ]
+ *  - window:    one of the BookingRecommendation::WINDOW_* constants
+ */
+
+use CommonsBooking\Model\Item;
+use CommonsBooking\View\BookAgain;
+use CommonsBooking\Wordpress\CustomPostType\Item as ItemCPT;
+
+global $templateData;
+
+$window      = $templateData['window'] ?? '';
+$windowLabel = BookAgain::getWindowLabel( $window );
+
+/**
+ * Renders a single suggestion card.
+ *
+ * @param array  $suggestion  [ 'itemId' => int, 'locationId' => ?int ]
+ * @param string $windowLabel Availability label, e.g. "free today".
+ *
+ * @return void
+ */
+$renderCard = function ( array $suggestion, string $windowLabel ): void {
+	$itemPost = get_post( $suggestion['itemId'] );
+	if ( ! $itemPost ) {
+		return;
+	}
+	$item = new Item( $itemPost );
+
+	// Deep link to the item page (with the free location preselected if known).
+	$bookUrl = get_the_permalink( $item->ID );
+	if ( ! empty( $suggestion['locationId'] ) ) {
+		$bookUrl = add_query_arg( 'cb-location', (int) $suggestion['locationId'], $bookUrl );
+	}
+
+	$categoryList = get_the_term_list(
+		$item->ID,
+		ItemCPT::getTaxonomyName(),
+		'',
+		', '
+	);
+	?>
+	<div class="cb-book-again-item cb-list-header">
+		<?php echo commonsbooking_sanitizeHTML( $item->thumbnail( 'cb_listing_medium' ) ); ?>
+		<div class="cb-list-info">
+			<h3><?php echo commonsbooking_sanitizeHTML( $item->titleLink() ); ?></h3>
+			<?php if ( $categoryList && ! is_wp_error( $categoryList ) ) { ?>
+				<div class="cb-book-again-categories"><?php echo commonsbooking_sanitizeHTML( $categoryList ); ?></div>
+			<?php } ?>
+			<div class="cb-status cb-availability-status cb-status-available cb-notice-small">
+				<?php echo esc_html( $windowLabel ); ?>
+			</div>
+			<a class="cb-button cb-book-again-button" href="<?php echo esc_url( $bookUrl ); ?>">
+				<?php echo esc_html__( 'Book again', 'commonsbooking' ); ?>
+			</a>
+		</div>
+	</div><!-- .cb-book-again-item -->
+	<?php
+};
+
+?>
+<div class="cb-wrapper cb-book-again template-shortcode-book-again">
+
+	<?php if ( ! empty( $templateData['bookAgain'] ) ) { ?>
+		<div class="cb-book-again-section cb-book-again-previous">
+			<h2><?php echo esc_html__( 'Book again', 'commonsbooking' ); ?></h2>
+			<div class="cb-book-again-list">
+				<?php
+				foreach ( $templateData['bookAgain'] as $suggestion ) {
+					$renderCard( $suggestion, $windowLabel );
+				}
+				?>
+			</div>
+		</div>
+	<?php } ?>
+
+	<?php if ( ! empty( $templateData['similar'] ) ) { ?>
+		<div class="cb-book-again-section cb-book-again-similar">
+			<h2><?php echo esc_html__( 'Did you try …', 'commonsbooking' ); ?></h2>
+			<div class="cb-book-again-list">
+				<?php
+				foreach ( $templateData['similar'] as $suggestion ) {
+					$renderCard( $suggestion, $windowLabel );
+				}
+				?>
+			</div>
+		</div>
+	<?php } ?>
+
+</div><!-- .cb-book-again -->

--- a/tests/php/Service/BookingRecommendationTest.php
+++ b/tests/php/Service/BookingRecommendationTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace CommonsBooking\Tests\Service;
+
+use CommonsBooking\Service\BookingRecommendation;
+use CommonsBooking\Tests\Wordpress\CustomPostTypeTest;
+use CommonsBooking\Wordpress\CustomPostType\Item;
+use SlopeIt\ClockMock\ClockMock;
+
+class BookingRecommendationTest extends CustomPostTypeTest {
+
+	/**
+	 * Bookable timeframe spanning the whole test window (-30 .. +30 days).
+	 *
+	 * @var int
+	 */
+	private $bookableTimeframeId;
+
+	public function testGetBookAgainSuggestionsReturnsPreviouslyBookedFreeItem() {
+		// The user has a past booking for the item, and the item is free from today on.
+		$suggestions = BookingRecommendation::getBookAgainSuggestions(
+			get_user_by( 'id', self::USER_ID ),
+			BookingRecommendation::WINDOW_WEEK
+		);
+
+		$itemIds = array_column( $suggestions, 'itemId' );
+		$this->assertContains( $this->itemId, $itemIds );
+	}
+
+	public function testGetBookAgainSuggestionsEmptyWithoutHistory() {
+		// A fresh subscriber without any bookings gets no "book again" suggestions.
+		$this->createSubscriber();
+		$subscriber = get_user_by( 'id', $this->subscriberId );
+
+		$suggestions = BookingRecommendation::getBookAgainSuggestions(
+			$subscriber,
+			BookingRecommendation::WINDOW_WEEK
+		);
+
+		$this->assertEmpty( $suggestions );
+	}
+
+	public function testGetBookAgainSuggestionsExcludesFullyBlockedItem() {
+		// Block the whole rolling week with a holiday -> item is not free anymore.
+		$this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-1 day', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+8 days', strtotime( self::CURRENT_DATE ) ),
+			\CommonsBooking\Wordpress\CustomPostType\Timeframe::HOLIDAYS_ID
+		);
+
+		$suggestions = BookingRecommendation::getBookAgainSuggestions(
+			get_user_by( 'id', self::USER_ID ),
+			BookingRecommendation::WINDOW_WEEK
+		);
+
+		$itemIds = array_column( $suggestions, 'itemId' );
+		$this->assertNotContains( $this->itemId, $itemIds );
+	}
+
+	public function testGetSimilarSuggestionsReturnsSameCategoryItem() {
+		// Create a sibling item in the same category, bookable and never booked.
+		$term = wp_create_term( 'Recommendation Test Category', Item::getTaxonomyName() );
+		wp_set_post_terms( $this->itemId, [ $term['term_id'] ], Item::getTaxonomyName() );
+
+		$siblingItemId = $this->createItem( 'SiblingItem' );
+		wp_set_post_terms( $siblingItemId, [ $term['term_id'] ], Item::getTaxonomyName() );
+		$this->createTimeframe(
+			$this->locationId,
+			$siblingItemId,
+			strtotime( '-30 days', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+30 days', strtotime( self::CURRENT_DATE ) )
+		);
+
+		$suggestions = BookingRecommendation::getSimilarSuggestions(
+			get_user_by( 'id', self::USER_ID ),
+			BookingRecommendation::WINDOW_WEEK
+		);
+
+		$itemIds = array_column( $suggestions, 'itemId' );
+		// The sibling is suggested, the already-booked item is not.
+		$this->assertContains( $siblingItemId, $itemIds );
+		$this->assertNotContains( $this->itemId, $itemIds );
+	}
+
+	public function testGetSimilarSuggestionsEmptyWithoutCategories() {
+		// The booked item has no category assigned -> nothing to base similarity on.
+		$suggestions = BookingRecommendation::getSimilarSuggestions(
+			get_user_by( 'id', self::USER_ID ),
+			BookingRecommendation::WINDOW_WEEK
+		);
+
+		$this->assertEmpty( $suggestions );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		ClockMock::freeze( new \DateTime( self::CURRENT_DATE ) );
+		wp_set_current_user( self::USER_ID );
+
+		// Item is bookable across the whole test window.
+		$this->bookableTimeframeId = $this->createTimeframe(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-30 days', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '+30 days', strtotime( self::CURRENT_DATE ) )
+		);
+
+		// The user booked the item in the past (does not block the current window).
+		$this->createBooking(
+			$this->locationId,
+			$this->itemId,
+			strtotime( '-10 days', strtotime( self::CURRENT_DATE ) ),
+			strtotime( '-9 days', strtotime( self::CURRENT_DATE ) ),
+			'12:00 AM',
+			'23:59',
+			'confirmed',
+			self::USER_ID
+		);
+	}
+
+	protected function tearDown(): void {
+		ClockMock::reset();
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
Introduce a personalised recommendation feature for logged-in users,
exposed via the new [cb_book_again] shortcode:

- "Book again": items the user has booked before that currently have a
  free bookable slot within a chosen window (today, tomorrow, or a
  rolling 7 days).
- "Did you try …": items sharing an item category with the user's
  previously booked items and free in the same window, excluding items
  the user already booked.

Implementation:
- Service\BookingRecommendation composes existing repositories. Free-slot
  detection reuses the Day grid logic (a slot is free when its
  highest-priority timeframe is bookable), so holidays, repairs,
  restrictions and existing bookings are respected exactly as the booking
  calendar respects them. Results are per-user cached with item/location
  tags and a daily (midnight) expiry.
- View\BookAgain renders the shortcode; it stays silent for logged-out
  users and when there is nothing to suggest.
- templates/shortcode-book-again.php renders item cards deep-linking to
  the item page with the free location preselected (?cb-location=).
- Register the [cb_book_again] shortcode.
- Unit tests for both sections and their edge cases.
- Document the shortcode (EN + DE).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0127MS1d3roPDabN2hcfo7pg